### PR TITLE
🔒 Finetune Slither Configurations

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -82,6 +82,6 @@ jobs:
 
       - name: Slither static analyser
         uses: crytic/slither-action@v0.3.0
-        continue-on-error: true
         with:
+          fail-on: config
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -82,6 +82,12 @@ jobs:
 
       - name: Slither static analyser
         uses: crytic/slither-action@v0.3.0
+        id: slither
         with:
           fail-on: config
           node-version: ${{ matrix.node_version }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -85,7 +85,7 @@ jobs:
         id: slither
         with:
           fail-on: config
-          node-version: ${{ matrix.node_version }}
+          sarif: results.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,7 +1,8 @@
 {
   "compile_force_framework": "foundry",
   "hardhat_ignore_compile": true,
-  "detectors_to_exclude": "pragma,solc-version,assembly,too-many-digits,low-level-calls,missing-zero-check,reentrancy-events",
+  "detectors_to_exclude": "pragma,solc-version,assembly,too-many-digits,low-level-calls,missing-zero-check,reentrancy-events,arbitrary-send-eth,naming-convention",
+  "fail_on": "high",
   "exclude_informational": false,
   "exclude_low": false,
   "exclude_medium": false,

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,7 +1,7 @@
 {
   "compile_force_framework": "foundry",
   "hardhat_ignore_compile": true,
-  "detectors_to_exclude": "pragma,solc-version,assembly,too-many-digits,low-level-calls",
+  "detectors_to_exclude": "pragma,solc-version,assembly,too-many-digits,low-level-calls,missing-zero-check,reentrancy-events",
   "exclude_informational": false,
   "exclude_low": false,
   "exclude_medium": false,

--- a/slither.config.json
+++ b/slither.config.json
@@ -2,7 +2,7 @@
   "compile_force_framework": "foundry",
   "hardhat_ignore_compile": true,
   "detectors_to_exclude": "pragma,solc-version,assembly,too-many-digits,low-level-calls,missing-zero-check,reentrancy-events,arbitrary-send-eth,naming-convention",
-  "fail_on": "high",
+  "fail_on": "none",
   "exclude_informational": false,
   "exclude_low": false,
   "exclude_medium": false,

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,7 +1,7 @@
 {
   "compile_force_framework": "foundry",
   "hardhat_ignore_compile": true,
-  "detectors_to_exclude": "pragma,solc-version",
+  "detectors_to_exclude": "pragma,solc-version,assembly,too-many-digits,low-level-calls",
   "exclude_informational": false,
   "exclude_low": false,
   "exclude_medium": false,

--- a/src/CreateX.sol
+++ b/src/CreateX.sol
@@ -23,7 +23,6 @@ contract CreateX {
     /**
      * @dev Caches the contract address at construction, to be used for the custom errors.
      */
-    // slither-disable-next-line naming-convention
     address internal immutable _SELF = address(this);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -155,7 +154,6 @@ contract CreateX {
         _requireSuccessfulContractCreation({newContract: newContract});
         emit ContractCreation({newContract: newContract});
 
-        // slither-disable-next-line arbitrary-send-eth
         (bool success, bytes memory returnData) = newContract.call{value: values.initCallAmount}(data);
         if (!success) {
             revert FailedContractInitialisation({emitter: _SELF, revertData: returnData});

--- a/src/CreateX.sol
+++ b/src/CreateX.sol
@@ -155,6 +155,7 @@ contract CreateX {
         _requireSuccessfulContractCreation({newContract: newContract});
         emit ContractCreation({newContract: newContract});
 
+        // slither-disable-next-line arbitrary-send-eth
         (bool success, bytes memory returnData) = newContract.call{value: values.initCallAmount}(data);
         if (!success) {
             revert FailedContractInitialisation({emitter: _SELF, revertData: returnData});

--- a/src/CreateX.sol
+++ b/src/CreateX.sol
@@ -23,6 +23,7 @@ contract CreateX {
     /**
      * @dev Caches the contract address at construction, to be used for the custom errors.
      */
+    // slither-disable-next-line naming-convention
     address internal immutable _SELF = address(this);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/


### PR DESCRIPTION
### 🕓 Changelog

This PR finetunes the Slither configuration file `slither.config.json` in a way that it excludes the detectors that are false positives for `CreateX` (for comparison see the warnings [here](https://github.com/pcaversaccio/createx/actions/runs/6637814580/job/18032879712#step:15:269)). Furthermore, I add an additional step in the CI that uploads the SARIF file. Note that `fail_on: none` is required to let the SARIF upload step run if Slither finds issues.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/8f38d8d1-65ee-41a2-8185-8e12890e428b)