### PR TITLE
♻️ Move `event`s, `error`s, and `struct`s Into the Interface `ICreateX`

### DIFF
--- a/src/CreateX.sol
+++ b/src/CreateX.sol
@@ -1,3 +1,5 @@
+import {ICreateX} from "./ICreateX.sol";
+
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.23;
 
@@ -15,7 +17,7 @@ pragma solidity 0.8.23;
  * the `CreateX` contract.
  * @custom:security-contact See https://web.archive.org/web/20230921105029/https://raw.githubusercontent.com/pcaversaccio/createx/main/SECURITY.md.
  */
-contract CreateX {
+contract CreateX is ICreateX {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         IMMUTABLES                         */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -28,14 +30,6 @@ contract CreateX {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                            TYPES                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-    /**
-     * @dev Struct for the `payable` amounts in a deploy-and-initialise call.
-     */
-    struct Values {
-        uint256 constructorAmount;
-        uint256 initCallAmount;
-    }
 
     /**
      * @dev Enum for the selection of a permissioned deploy protection.
@@ -54,66 +48,6 @@ contract CreateX {
         False,
         Unspecified
     }
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                           EVENTS                           */
-    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-    /**
-     * @dev Event that is emitted when a contract is successfully created.
-     * @param newContract The address of the new contract.
-     * @param salt The 32-byte random value used to create the contract address.
-     */
-    event ContractCreation(address indexed newContract, bytes32 indexed salt);
-
-    /**
-     * @dev Event that is emitted when a contract is successfully created.
-     * @param newContract The address of the new contract.
-     */
-    event ContractCreation(address indexed newContract);
-
-    /**
-     * @dev Event that is emitted when a `CREATE3` proxy contract is successfully created.
-     * @param newContract The address of the new proxy contract.
-     * @param salt The 32-byte random value used to create the proxy address.
-     */
-    event Create3ProxyContractCreation(address indexed newContract, bytes32 indexed salt);
-
-    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
-    /*                        CUSTOM ERRORS                       */
-    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
-
-    /**
-     * @dev Error that occurs when the contract creation failed.
-     * @param emitter The contract that emits the error.
-     */
-    error FailedContractCreation(address emitter);
-
-    /**
-     * @dev Error that occurs when the contract initialisation call failed.
-     * @param emitter The contract that emits the error.
-     * @param revertData The data returned by the failed initialisation call.
-     */
-    error FailedContractInitialisation(address emitter, bytes revertData);
-
-    /**
-     * @dev Error that occurs when the salt value is invalid.
-     * @param emitter The contract that emits the error.
-     */
-    error InvalidSalt(address emitter);
-
-    /**
-     * @dev Error that occurs when the nonce value is invalid.
-     * @param emitter The contract that emits the error.
-     */
-    error InvalidNonceValue(address emitter);
-
-    /**
-     * @dev Error that occurs when transferring ether has failed.
-     * @param emitter The contract that emits the error.
-     * @param revertData The data returned by the failed ether transfer.
-     */
-    error FailedEtherTransfer(address emitter, bytes revertData);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           CREATE                           */
@@ -150,12 +84,11 @@ contract CreateX {
      * a mutex lock to keep it as use-case agnostic as possible. Please ensure at the protocol
      * level that potentially malicious reentrant calls do not affect your smart contract system.
      */
-    function deployCreateAndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values,
-        address refundAddress
-    ) public payable returns (address newContract) {
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        public
+        payable
+        returns (address newContract)
+    {
         assembly ("memory-safe") {
             newContract := create(mload(values), add(initCode, 0x20), mload(initCode))
         }
@@ -191,11 +124,11 @@ contract CreateX {
      * a mutex lock to keep it as use-case agnostic as possible. Please ensure at the protocol
      * level that potentially malicious reentrant calls do not affect your smart contract system.
      */
-    function deployCreateAndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         newContract = deployCreateAndInit({initCode: initCode, data: data, values: values, refundAddress: msg.sender});
     }
 
@@ -215,15 +148,9 @@ contract CreateX {
         bytes20 implementationInBytes = bytes20(implementation);
         assembly ("memory-safe") {
             let clone := mload(0x40)
-            mstore(
-                clone,
-                hex"3d_60_2d_80_60_0a_3d_39_81_f3_36_3d_3d_37_3d_3d_3d_36_3d_73_00_00_00_00_00_00_00_00_00_00_00_00"
-            )
+            mstore(clone, hex"3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000")
             mstore(add(clone, 0x14), implementationInBytes)
-            mstore(
-                add(clone, 0x28),
-                hex"5a_f4_3d_82_80_3e_90_3d_91_60_2b_57_fd_5b_f3_00_00_00_00_00_00_00_00_00_00_00_00_00_00_00_00_00"
-            )
+            mstore(add(clone, 0x28), hex"5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000")
             proxy := create(0, clone, 0x37)
         }
         if (proxy == address(0)) {
@@ -413,12 +340,11 @@ contract CreateX {
      * a mutex lock to keep it as use-case agnostic as possible. Please ensure at the protocol
      * level that potentially malicious reentrant calls do not affect your smart contract system.
      */
-    function deployCreate2AndInit(
-        bytes32 salt,
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate2AndInit(bytes32 salt, bytes memory initCode, bytes memory data, Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         // Note that the safeguarding function `_guard` is called as part of the overloaded function
         // `deployCreate2AndInit`.
         newContract = deployCreate2AndInit({
@@ -447,12 +373,11 @@ contract CreateX {
      * a mutex lock to keep it as use-case agnostic as possible. Please ensure at the protocol
      * level that potentially malicious reentrant calls do not affect your smart contract system.
      */
-    function deployCreate2AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values,
-        address refundAddress
-    ) public payable returns (address newContract) {
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        public
+        payable
+        returns (address newContract)
+    {
         // Note that the safeguarding function `_guard` is called as part of the overloaded function
         // `deployCreate2AndInit`.
         newContract = deployCreate2AndInit({
@@ -480,11 +405,11 @@ contract CreateX {
      * a mutex lock to keep it as use-case agnostic as possible. Please ensure at the protocol
      * level that potentially malicious reentrant calls do not affect your smart contract system.
      */
-    function deployCreate2AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         // Note that the safeguarding function `_guard` is called as part of the overloaded function
         // `deployCreate2AndInit`.
         newContract = deployCreate2AndInit({
@@ -509,24 +434,18 @@ contract CreateX {
      * a mutex lock to keep it as use-case agnostic as possible. Please ensure at the protocol
      * level that potentially malicious reentrant calls do not affect your smart contract system.
      */
-    function deployCreate2Clone(
-        bytes32 salt,
-        address implementation,
-        bytes memory data
-    ) public payable returns (address proxy) {
+    function deployCreate2Clone(bytes32 salt, address implementation, bytes memory data)
+        public
+        payable
+        returns (address proxy)
+    {
         bytes32 guardedSalt = _guard({salt: salt});
         bytes20 implementationInBytes = bytes20(implementation);
         assembly ("memory-safe") {
             let clone := mload(0x40)
-            mstore(
-                clone,
-                hex"3d_60_2d_80_60_0a_3d_39_81_f3_36_3d_3d_37_3d_3d_3d_36_3d_73_00_00_00_00_00_00_00_00_00_00_00_00"
-            )
+            mstore(clone, hex"3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000")
             mstore(add(clone, 0x14), implementationInBytes)
-            mstore(
-                add(clone, 0x28),
-                hex"5a_f4_3d_82_80_3e_90_3d_91_60_2b_57_fd_5b_f3_00_00_00_00_00_00_00_00_00_00_00_00_00_00_00_00_00"
-            )
+            mstore(add(clone, 0x28), hex"5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000")
             proxy := create2(0, clone, 0x37, guardedSalt)
         }
         if (proxy == address(0)) {
@@ -572,11 +491,11 @@ contract CreateX {
      * @param deployer The 20-byte deployer address.
      * @return computedAddress The 20-byte address where a contract will be stored.
      */
-    function computeCreate2Address(
-        bytes32 salt,
-        bytes32 initCodeHash,
-        address deployer
-    ) public pure returns (address computedAddress) {
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer)
+        public
+        pure
+        returns (address computedAddress)
+    {
         assembly ("memory-safe") {
             // |                      | ↓ ptr ...  ↓ ptr + 0x0B (start) ...  ↓ ptr + 0x20 ...  ↓ ptr + 0x40 ...   |
             // |----------------------|---------------------------------------------------------------------------|
@@ -629,7 +548,7 @@ contract CreateX {
      */
     function deployCreate3(bytes32 salt, bytes memory initCode) public payable returns (address newContract) {
         bytes32 guardedSalt = _guard({salt: salt});
-        bytes memory proxyChildBytecode = hex"67_36_3d_3d_37_36_3d_34_f0_3d_52_60_08_60_18_f3";
+        bytes memory proxyChildBytecode = hex"67363d3d37363d34f03d5260086018f3";
         address proxy;
         assembly ("memory-safe") {
             proxy := create2(0, add(proxyChildBytecode, 32), mload(proxyChildBytecode), guardedSalt)
@@ -640,7 +559,7 @@ contract CreateX {
         emit Create3ProxyContractCreation({newContract: proxy, salt: guardedSalt});
 
         newContract = computeCreate3Address({salt: guardedSalt});
-        (bool success, ) = proxy.call{value: msg.value}(initCode);
+        (bool success,) = proxy.call{value: msg.value}(initCode);
         _requireSuccessfulContractCreation({success: success, newContract: newContract});
         emit ContractCreation({newContract: newContract});
     }
@@ -693,7 +612,7 @@ contract CreateX {
         address refundAddress
     ) public payable returns (address newContract) {
         bytes32 guardedSalt = _guard({salt: salt});
-        bytes memory proxyChildBytecode = hex"67_36_3d_3d_37_36_3d_34_f0_3d_52_60_08_60_18_f3";
+        bytes memory proxyChildBytecode = hex"67363d3d37363d34f03d5260086018f3";
         address proxy;
         assembly ("memory-safe") {
             proxy := create2(0, add(proxyChildBytecode, 32), mload(proxyChildBytecode), guardedSalt)
@@ -704,7 +623,7 @@ contract CreateX {
         emit Create3ProxyContractCreation({newContract: proxy, salt: guardedSalt});
 
         newContract = computeCreate3Address({salt: guardedSalt});
-        (bool success, ) = proxy.call{value: values.constructorAmount}(initCode);
+        (bool success,) = proxy.call{value: values.constructorAmount}(initCode);
         _requireSuccessfulContractCreation({success: success, newContract: newContract});
         emit ContractCreation({newContract: newContract});
 
@@ -744,12 +663,11 @@ contract CreateX {
      * the first 20 bytes equal to `msg.sender` in the `salt` to prevent maliciously intended frontrun
      * proxy deployments on other chains.
      */
-    function deployCreate3AndInit(
-        bytes32 salt,
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate3AndInit(bytes32 salt, bytes memory initCode, bytes memory data, Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         // Note that the safeguarding function `_guard` is called as part of the overloaded function
         // `deployCreate3AndInit`.
         newContract = deployCreate3AndInit({
@@ -781,12 +699,11 @@ contract CreateX {
      * Furthermore, this function does not implement any permissioned deploy protection, thus
      * anyone can frontrun the same proxy deployment on other chains. Use with caution!
      */
-    function deployCreate3AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values,
-        address refundAddress
-    ) public payable returns (address newContract) {
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        public
+        payable
+        returns (address newContract)
+    {
         // Note that the safeguarding function `_guard` is called as part of the overloaded function
         // `deployCreate3AndInit`.
         newContract = deployCreate3AndInit({
@@ -817,11 +734,11 @@ contract CreateX {
      * Furthermore, this function does not implement any permissioned deploy protection, thus
      * anyone can frontrun the same proxy deployment on other chains. Use with caution!
      */
-    function deployCreate3AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         // Note that the safeguarding function `_guard` is called as part of the overloaded function
         // `deployCreate3AndInit`.
         newContract = deployCreate3AndInit({
@@ -848,10 +765,7 @@ contract CreateX {
             mstore(0x00, deployer)
             mstore8(0x0b, 0xff)
             mstore(0x20, salt)
-            mstore(
-                0x40,
-                hex"21_c3_5d_be_1b_34_4a_24_88_cf_33_21_d6_ce_54_2f_8e_9f_30_55_44_ff_09_e4_99_3a_62_31_9a_49_7c_1f"
-            )
+            mstore(0x40, hex"21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f")
             mstore(0x14, keccak256(0x0b, 0x55))
             mstore(0x40, ptr)
             mstore(0x00, 0xd694)
@@ -924,9 +838,11 @@ contract CreateX {
      * @return redeployProtectionFlag The 8-byte enum for the selection of a cross-chain redeploy
      * protection.
      */
-    function _parseSalt(
-        bytes32 salt
-    ) internal view returns (SenderBytes senderBytes, RedeployProtectionFlag redeployProtectionFlag) {
+    function _parseSalt(bytes32 salt)
+        internal
+        view
+        returns (SenderBytes senderBytes, RedeployProtectionFlag redeployProtectionFlag)
+    {
         if (address(bytes20(salt)) == msg.sender && bytes1(salt[20]) == hex"01") {
             (senderBytes, redeployProtectionFlag) = (SenderBytes.MsgSender, RedeployProtectionFlag.True);
         } else if (address(bytes20(salt)) == msg.sender && bytes1(salt[20]) == hex"00") {
@@ -1025,11 +941,10 @@ contract CreateX {
      * @param returnData The return data from the contract initialisation call.
      * @param implementation The 20-byte address where the implementation was deployed.
      */
-    function _requireSuccessfulContractInitialisation(
-        bool success,
-        bytes memory returnData,
-        address implementation
-    ) internal view {
+    function _requireSuccessfulContractInitialisation(bool success, bytes memory returnData, address implementation)
+        internal
+        view
+    {
         if (!success || implementation.code.length == 0) {
             revert FailedContractInitialisation({emitter: _SELF, revertData: returnData});
         }

--- a/src/ICreateX.sol
+++ b/src/ICreateX.sol
@@ -11,6 +11,9 @@ interface ICreateX {
     /*                            TYPES                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
+    /**
+     * @dev Struct for the `payable` amounts in a deploy-and-initialise call.
+     */
     struct Values {
         uint256 constructorAmount;
         uint256 initCallAmount;
@@ -20,18 +23,60 @@ interface ICreateX {
     /*                           EVENTS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
+    /**
+     * @dev Event that is emitted when a contract is successfully created.
+     * @param newContract The address of the new contract.
+     * @param salt The 32-byte random value used to create the contract address.
+     */
     event ContractCreation(address indexed newContract, bytes32 indexed salt);
+
+    /**
+     * @dev Event that is emitted when a contract is successfully created.
+     * @param newContract The address of the new contract.
+     */
     event ContractCreation(address indexed newContract);
+
+    /**
+     * @dev Event that is emitted when a `CREATE3` proxy contract is successfully created.
+     * @param newContract The address of the new proxy contract.
+     * @param salt The 32-byte random value used to create the proxy address.
+     */
     event Create3ProxyContractCreation(address indexed newContract, bytes32 indexed salt);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                        CUSTOM ERRORS                       */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
+    /**
+     * @dev Error that occurs when the contract creation failed.
+     * @param emitter The contract that emits the error.
+     */
     error FailedContractCreation(address emitter);
+
+    /**
+     * @dev Error that occurs when the contract initialisation call failed.
+     * @param emitter The contract that emits the error.
+     * @param revertData The data returned by the failed initialisation call.
+     */
     error FailedContractInitialisation(address emitter, bytes revertData);
+
+    /**
+     * @dev Error that occurs when the salt value is invalid.
+     * @param emitter The contract that emits the error.
+     */
     error InvalidSalt(address emitter);
+
+    /**
+     * @dev Error that occurs when the nonce value is invalid.
+     * @param emitter The contract that emits the error.
+     */
     error InvalidNonceValue(address emitter);
+
+    /**
+     * @dev Error that occurs when transferring ether has failed.
+     * @param emitter The contract that emits the error.
+     * @param revertData The data returned by the failed ether transfer.
+     */
     error FailedEtherTransfer(address emitter, bytes revertData);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -40,18 +85,15 @@ interface ICreateX {
 
     function deployCreate(bytes memory initCode) external payable returns (address newContract);
 
-    function deployCreateAndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values,
-        address refundAddress
-    ) external payable returns (address newContract);
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        external
+        payable
+        returns (address newContract);
 
-    function deployCreateAndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) external payable returns (address newContract);
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
 
     function deployCreateClone(address implementation, bytes memory data) external payable returns (address proxy);
 
@@ -75,41 +117,37 @@ interface ICreateX {
         address refundAddress
     ) external payable returns (address newContract);
 
-    function deployCreate2AndInit(
-        bytes32 salt,
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) external payable returns (address newContract);
+    function deployCreate2AndInit(bytes32 salt, bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
 
-    function deployCreate2AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values,
-        address refundAddress
-    ) external payable returns (address newContract);
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        external
+        payable
+        returns (address newContract);
 
-    function deployCreate2AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) external payable returns (address newContract);
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
 
-    function deployCreate2Clone(
-        bytes32 salt,
-        address implementation,
-        bytes memory data
-    ) external payable returns (address proxy);
+    function deployCreate2Clone(bytes32 salt, address implementation, bytes memory data)
+        external
+        payable
+        returns (address proxy);
 
     function deployCreate2Clone(address implementation, bytes memory data) external payable returns (address proxy);
 
-    function computeCreate2Address(
-        bytes32 salt,
-        bytes32 initCodeHash,
-        address deployer
-    ) external pure returns (address computedAddress);
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash, address deployer)
+        external
+        pure
+        returns (address computedAddress);
 
-    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) external view returns (address computedAddress);
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash)
+        external
+        view
+        returns (address computedAddress);
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                           CREATE3                          */
@@ -127,25 +165,20 @@ interface ICreateX {
         address refundAddress
     ) external payable returns (address newContract);
 
-    function deployCreate3AndInit(
-        bytes32 salt,
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) external payable returns (address newContract);
+    function deployCreate3AndInit(bytes32 salt, bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
 
-    function deployCreate3AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values,
-        address refundAddress
-    ) external payable returns (address newContract);
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values, address refundAddress)
+        external
+        payable
+        returns (address newContract);
 
-    function deployCreate3AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        Values memory values
-    ) external payable returns (address newContract);
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, Values memory values)
+        external
+        payable
+        returns (address newContract);
 
     function computeCreate3Address(bytes32 salt, address deployer) external pure returns (address computedAddress);
 

--- a/test/internal/CreateX._guard.t.sol
+++ b/test/internal/CreateX._guard.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {BaseTest} from "../utils/BaseTest.sol";
-import {CreateX} from "../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../src/CreateX.sol";
 
 contract CreateX_Guard_Internal_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -88,7 +88,7 @@ contract CreateX_Guard_Internal_Test is BaseTest {
     ) external whenTheFirst20BytesOfTheSaltEqualsTheCaller(caller, salt) whenThe21stByteOfTheSaltIsGreaterThan0x01 {
         vm.startPrank(caller);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_guard(cachedSalt);
         vm.stopPrank();
@@ -130,7 +130,7 @@ contract CreateX_Guard_Internal_Test is BaseTest {
     ) external whenTheFirst20BytesOfTheSaltEqualsTheZeroAddress(salt) whenThe21stByteOfTheSaltIsGreaterThan0x01 {
         vm.startPrank(caller);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_guard(cachedSalt);
         vm.stopPrank();
@@ -142,10 +142,10 @@ contract CreateX_Guard_Internal_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheFirst20BytesOfTheSaltDoNotEqualTheCallerOrTheZeroAddress(
-        address caller,
-        bytes32 salt
-    ) external whenTheFirst20BytesOfTheSaltDoNotEqualTheCallerOrTheZeroAddress(caller, salt) {
+    function testFuzz_WhenTheFirst20BytesOfTheSaltDoNotEqualTheCallerOrTheZeroAddress(address caller, bytes32 salt)
+        external
+        whenTheFirst20BytesOfTheSaltDoNotEqualTheCallerOrTheZeroAddress(caller, salt)
+    {
         vm.startPrank(caller);
         // It should return the unmodified salt value.
         bytes32 guardedSalt = createXHarness.exposed_guard(cachedSalt);

--- a/test/internal/CreateX._parseSalt.t.sol
+++ b/test/internal/CreateX._parseSalt.t.sol
@@ -77,8 +77,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.MsgSender` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.True` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.MsgSender, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.True, "200");
@@ -102,8 +102,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.MsgSender` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.False` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.MsgSender, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.False, "200");
@@ -133,8 +133,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.MsgSender` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.Unspecified` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.MsgSender, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.Unspecified, "200");
@@ -154,8 +154,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.ZeroAddress` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.True` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.ZeroAddress, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.True, "200");
@@ -169,8 +169,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.ZeroAddress` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.False` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.ZeroAddress, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.False, "200");
@@ -184,8 +184,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.ZeroAddress` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.Unspecified` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.ZeroAddress, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.Unspecified, "200");
@@ -208,8 +208,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.Random` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.True` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.Random, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.True, "200");
@@ -226,8 +226,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.Random` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.False` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.Random, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.False, "200");
@@ -244,8 +244,8 @@ contract CreateX_ParseSalt_Internal_Test is BaseTest {
         vm.startPrank(caller);
         // It should return the `SenderBytes.Random` `enum` as first return value.
         // It should return the `RedeployProtectionFlag.Unspecified` `enum` as second return value.
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(cachedSalt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(cachedSalt);
         vm.stopPrank();
         assertEq(senderBytes, CreateX.SenderBytes.Random, "100");
         assertEq(redeployProtectionFlag, CreateX.RedeployProtectionFlag.Unspecified, "200");

--- a/test/internal/CreateX._requireSuccessfulContractCreation_1Arg.t.sol
+++ b/test/internal/CreateX._requireSuccessfulContractCreation_1Arg.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {BaseTest} from "../utils/BaseTest.sol";
-import {CreateX} from "../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../src/CreateX.sol";
 
 contract CreateX_RequireSuccessfulContractCreation_1Arg_Internal_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -15,7 +15,7 @@ contract CreateX_RequireSuccessfulContractCreation_1Arg_Internal_Test is BaseTes
 
     function test_WhenTheNewContractAddressIsTheZeroAddress() external whenTheNewContractAddressIsTheZeroAddress {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractCreation(zeroAddress);
     }
@@ -35,15 +35,13 @@ contract CreateX_RequireSuccessfulContractCreation_1Arg_Internal_Test is BaseTes
         _;
     }
 
-    function testFuzz_WhenTheNewContractAddressHasNoCode(
-        address newContract
-    )
+    function testFuzz_WhenTheNewContractAddressHasNoCode(address newContract)
         external
         whenTheNewContractAddressIsNotTheZeroAddress(newContract)
         whenTheNewContractAddressHasNoCode(newContract)
     {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractCreation(newContract);
     }
@@ -57,9 +55,11 @@ contract CreateX_RequireSuccessfulContractCreation_1Arg_Internal_Test is BaseTes
         _;
     }
 
-    function testFuzz_WhenTheNewContractAddressHasCode(
-        address newContract
-    ) external whenTheNewContractAddressIsNotTheZeroAddress(newContract) whenTheNewContractAddressHasCode(newContract) {
+    function testFuzz_WhenTheNewContractAddressHasCode(address newContract)
+        external
+        whenTheNewContractAddressIsNotTheZeroAddress(newContract)
+        whenTheNewContractAddressHasCode(newContract)
+    {
         // It should never revert. We do not need any assertions to test this.
         createXHarness.exposed_requireSuccessfulContractCreation(newContract);
     }

--- a/test/internal/CreateX._requireSuccessfulContractCreation_2Args.t.sol
+++ b/test/internal/CreateX._requireSuccessfulContractCreation_2Args.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {BaseTest} from "../utils/BaseTest.sol";
-import {CreateX} from "../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../src/CreateX.sol";
 
 contract CreateX_RequireSuccessfulContractCreation_2Args_Internal_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -15,7 +15,7 @@ contract CreateX_RequireSuccessfulContractCreation_2Args_Internal_Test is BaseTe
 
     function testFuzz_WhenTheSuccessBooleanIsFalse(address newContract) external whenTheSuccessBooleanIsFalse {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractCreation(false, newContract);
     }
@@ -34,7 +34,7 @@ contract CreateX_RequireSuccessfulContractCreation_2Args_Internal_Test is BaseTe
         whenTheNewContractAddressIsTheZeroAddress
     {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractCreation(true, zeroAddress);
     }
@@ -55,17 +55,14 @@ contract CreateX_RequireSuccessfulContractCreation_2Args_Internal_Test is BaseTe
         _;
     }
 
-    function testFuzz_WhenTheNewContractAddressHasNoCode(
-        bool success,
-        address newContract
-    )
+    function testFuzz_WhenTheNewContractAddressHasNoCode(bool success, address newContract)
         external
         whenTheSuccessBooleanIsTrue
         whenTheNewContractAddressIsNotTheZeroAddress(newContract)
         whenTheNewContractAddressHasNoCode(newContract)
     {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXHarnessAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXHarnessAddr);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractCreation(success, newContract);
     }
@@ -80,9 +77,7 @@ contract CreateX_RequireSuccessfulContractCreation_2Args_Internal_Test is BaseTe
         _;
     }
 
-    function testFuzz_WhenTheNewContractAddressHasCode(
-        address newContract
-    )
+    function testFuzz_WhenTheNewContractAddressHasCode(address newContract)
         external
         whenTheSuccessBooleanIsTrue
         whenTheNewContractAddressIsNotTheZeroAddress(newContract)

--- a/test/internal/CreateX._requireSuccessfulContractInitialisation.t.sol
+++ b/test/internal/CreateX._requireSuccessfulContractInitialisation.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {BaseTest} from "../utils/BaseTest.sol";
-import {CreateX} from "../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../src/CreateX.sol";
 
 contract CreateX_RequireSuccessfulContractInitialisation_Internal_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -13,16 +13,13 @@ contract CreateX_RequireSuccessfulContractInitialisation_Internal_Test is BaseTe
         _;
     }
 
-    function testFuzz_WhenTheSuccessBooleanIsFalse(
-        bytes memory returnData,
-        address implementation
-    ) external whenTheSuccessBooleanIsFalse {
+    function testFuzz_WhenTheSuccessBooleanIsFalse(bytes memory returnData, address implementation)
+        external
+        whenTheSuccessBooleanIsFalse
+    {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXHarnessAddr,
-            returnData
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXHarnessAddr, returnData);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractInitialisation(false, returnData, implementation);
     }
@@ -42,16 +39,14 @@ contract CreateX_RequireSuccessfulContractInitialisation_Internal_Test is BaseTe
         _;
     }
 
-    function testFuzz_WhenTheImplementationAddressHasNoCode(
-        bytes memory returnData,
-        address implementation
-    ) external whenTheSuccessBooleanIsTrue whenTheImplementationAddressHasNoCode(implementation) {
+    function testFuzz_WhenTheImplementationAddressHasNoCode(bytes memory returnData, address implementation)
+        external
+        whenTheSuccessBooleanIsTrue
+        whenTheImplementationAddressHasNoCode(implementation)
+    {
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXHarnessAddr,
-            returnData
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXHarnessAddr, returnData);
         vm.expectRevert(expectedErr);
         createXHarness.exposed_requireSuccessfulContractInitialisation(true, returnData, implementation);
     }
@@ -66,10 +61,11 @@ contract CreateX_RequireSuccessfulContractInitialisation_Internal_Test is BaseTe
         _;
     }
 
-    function testFuzz_WhenTheImplementationAddressHasCode(
-        bytes memory returnData,
-        address implementation
-    ) external whenTheSuccessBooleanIsTrue whenTheImplementationAddressHasCode(implementation) {
+    function testFuzz_WhenTheImplementationAddressHasCode(bytes memory returnData, address implementation)
+        external
+        whenTheSuccessBooleanIsTrue
+        whenTheImplementationAddressHasCode(implementation)
+    {
         // It should never revert.
         createXHarness.exposed_requireSuccessfulContractInitialisation(true, returnData, implementation);
     }

--- a/test/invariants/CreateX_Invariants.t.sol
+++ b/test/invariants/CreateX_Invariants.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {Test} from "forge-std/Test.sol";
-import {CreateX} from "../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../src/CreateX.sol";
 
 contract CreateX_Invariants is Test {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -57,18 +57,18 @@ contract CreateXHandler {
     function deployCreateAndInit(
         bytes memory initCode,
         bytes memory data,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         address refundAddress
     ) public payable returns (address newContract) {
         newContract = createX.deployCreateAndInit(initCode, data, values, refundAddress);
         updatedBalance = 0;
     }
 
-    function deployCreateAndInit(
-        bytes memory initCode,
-        bytes memory data,
-        CreateX.Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreateAndInit(bytes memory initCode, bytes memory data, ICreateX.Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         newContract = createX.deployCreateAndInit(initCode, data, values);
         updatedBalance = 0;
     }
@@ -93,19 +93,18 @@ contract CreateXHandler {
         bytes32 salt,
         bytes memory initCode,
         bytes memory data,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         address refundAddress
     ) public payable returns (address newContract) {
         newContract = createX.deployCreate2AndInit(salt, initCode, data, values, refundAddress);
         updatedBalance = 0;
     }
 
-    function deployCreate2AndInit(
-        bytes32 salt,
-        bytes memory initCode,
-        bytes memory data,
-        CreateX.Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate2AndInit(bytes32 salt, bytes memory initCode, bytes memory data, ICreateX.Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         newContract = createX.deployCreate2AndInit(salt, initCode, data, values);
         updatedBalance = 0;
     }
@@ -113,27 +112,27 @@ contract CreateXHandler {
     function deployCreate2AndInit(
         bytes memory initCode,
         bytes memory data,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         address refundAddress
     ) public payable returns (address newContract) {
         newContract = createX.deployCreate2AndInit(initCode, data, values, refundAddress);
         updatedBalance = 0;
     }
 
-    function deployCreate2AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        CreateX.Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate2AndInit(bytes memory initCode, bytes memory data, ICreateX.Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         newContract = createX.deployCreate2AndInit(initCode, data, values);
         updatedBalance = 0;
     }
 
-    function deployCreate2Clone(
-        bytes32 salt,
-        address implementation,
-        bytes memory data
-    ) public payable returns (address proxy) {
+    function deployCreate2Clone(bytes32 salt, address implementation, bytes memory data)
+        public
+        payable
+        returns (address proxy)
+    {
         proxy = createX.deployCreate2Clone(salt, implementation, data);
     }
 
@@ -157,19 +156,18 @@ contract CreateXHandler {
         bytes32 salt,
         bytes memory initCode,
         bytes memory data,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         address refundAddress
     ) public payable returns (address newContract) {
         newContract = createX.deployCreate3AndInit(salt, initCode, data, values, refundAddress);
         updatedBalance = 0;
     }
 
-    function deployCreate3AndInit(
-        bytes32 salt,
-        bytes memory initCode,
-        bytes memory data,
-        CreateX.Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate3AndInit(bytes32 salt, bytes memory initCode, bytes memory data, ICreateX.Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         newContract = createX.deployCreate3AndInit(salt, initCode, data, values);
         updatedBalance = 0;
     }
@@ -177,18 +175,18 @@ contract CreateXHandler {
     function deployCreate3AndInit(
         bytes memory initCode,
         bytes memory data,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         address refundAddress
     ) public payable returns (address newContract) {
         newContract = createX.deployCreate3AndInit(initCode, data, values, refundAddress);
         updatedBalance = 0;
     }
 
-    function deployCreate3AndInit(
-        bytes memory initCode,
-        bytes memory data,
-        CreateX.Values memory values
-    ) public payable returns (address newContract) {
+    function deployCreate3AndInit(bytes memory initCode, bytes memory data, ICreateX.Values memory values)
+        public
+        payable
+        returns (address newContract)
+    {
         newContract = createX.deployCreate3AndInit(initCode, data, values);
         updatedBalance = 0;
     }

--- a/test/mocks/ERC20MockPayable.sol
+++ b/test/mocks/ERC20MockPayable.sol
@@ -11,12 +11,10 @@ import {ERC20} from "openzeppelin/token/ERC20/ERC20.sol";
  * @dev Allows to mock a simple `payable` ERC-20 implementation.
  */
 contract ERC20MockPayable is ERC20 {
-    constructor(
-        string memory name_,
-        string memory symbol_,
-        address initialAccount_,
-        uint256 initialBalance_
-    ) payable ERC20(name_, symbol_) {
+    constructor(string memory name_, string memory symbol_, address initialAccount_, uint256 initialBalance_)
+        payable
+        ERC20(name_, symbol_)
+    {
         _mint({account: initialAccount_, value: initialBalance_});
     }
 

--- a/test/public/CREATE/CreateX.computeCreateAddress_1Arg.t.sol
+++ b/test/public/CREATE/CreateX.computeCreateAddress_1Arg.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {BaseTest} from "../../utils/BaseTest.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_ComputeCreateAddress_1Arg_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -21,9 +21,10 @@ contract CreateX_ComputeCreateAddress_1Arg_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheNonceValueDoesNotExceed18446744073709551614(
-        uint64 nonce
-    ) external whenTheNonceValueDoesNotExceed18446744073709551614(nonce) {
+    function testFuzz_WhenTheNonceValueDoesNotExceed18446744073709551614(uint64 nonce)
+        external
+        whenTheNonceValueDoesNotExceed18446744073709551614(nonce)
+    {
         vm.startPrank(createXAddr);
         address createAddressComputedOnChain = address(new CreateX());
         vm.stopPrank();
@@ -36,10 +37,11 @@ contract CreateX_ComputeCreateAddress_1Arg_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheNonceValueExceeds18446744073709551614(
-        uint256 nonce
-    ) external whenTheNonceValueExceeds18446744073709551614(nonce) {
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidNonceValue.selector, createXAddr);
+    function testFuzz_WhenTheNonceValueExceeds18446744073709551614(uint256 nonce)
+        external
+        whenTheNonceValueExceeds18446744073709551614(nonce)
+    {
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidNonceValue.selector, createXAddr);
         vm.expectRevert(expectedErr);
         // It should revert.
         createX.computeCreateAddress(cachedNonce);

--- a/test/public/CREATE/CreateX.computeCreateAddress_2Args.t.sol
+++ b/test/public/CREATE/CreateX.computeCreateAddress_2Args.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.23;
 
 import {BaseTest} from "../../utils/BaseTest.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_ComputeCreateAddress_2Args_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -24,10 +24,10 @@ contract CreateX_ComputeCreateAddress_2Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheNonceValueDoesNotExceed18446744073709551614(
-        address deployer,
-        uint64 nonce
-    ) external whenTheNonceValueDoesNotExceed18446744073709551614(deployer, nonce) {
+    function testFuzz_WhenTheNonceValueDoesNotExceed18446744073709551614(address deployer, uint64 nonce)
+        external
+        whenTheNonceValueDoesNotExceed18446744073709551614(deployer, nonce)
+    {
         vm.startPrank(deployer);
         address createAddressComputedOnChain = address(new CreateX());
         vm.stopPrank();
@@ -40,11 +40,11 @@ contract CreateX_ComputeCreateAddress_2Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheNonceValueExceeds18446744073709551614(
-        address deployer,
-        uint256 nonce
-    ) external whenTheNonceValueExceeds18446744073709551614(nonce) {
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidNonceValue.selector, createXAddr);
+    function testFuzz_WhenTheNonceValueExceeds18446744073709551614(address deployer, uint256 nonce)
+        external
+        whenTheNonceValueExceeds18446744073709551614(nonce)
+    {
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidNonceValue.selector, createXAddr);
         vm.expectRevert(expectedErr);
         // It should revert.
         createX.computeCreateAddress(deployer, cachedNonce);

--- a/test/public/CREATE/CreateX.deployCreateAndInit_3Args.t.sol
+++ b/test/public/CREATE/CreateX.deployCreateAndInit_3Args.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -34,7 +34,7 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         uint64 nonce,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     )
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
@@ -53,13 +53,11 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address as indexed argument.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         vm.deal(arg3, values.constructorAmount + values.initCallAmount);
         vm.startPrank(arg3);
         address newContract = createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
 
@@ -85,7 +83,7 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         uint64 nonce,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint256 amount
     )
         external
@@ -107,13 +105,11 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address as indexed argument.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         vm.deal(arg3, values.constructorAmount + values.initCallAmount);
         vm.startPrank(arg3);
         address newContract = createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
 
@@ -135,7 +131,7 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
         uint64 nonce,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint256 amount
     )
         external
@@ -151,16 +147,11 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         vm.deal(SELF, values.constructorAmount + values.initCallAmount);
         vm.startPrank(SELF);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedEtherTransfer.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
     }
@@ -169,10 +160,7 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
-        uint64 nonce,
-        CreateX.Values memory values
-    )
+    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(uint64 nonce, ICreateX.Values memory values)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsUnsuccessful
@@ -184,16 +172,11 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         vm.deal(arg3, values.constructorAmount + values.initCallAmount);
         vm.startPrank(arg3);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeWithSignature("wagmi"),
-            values
+            cachedInitCode, abi.encodeWithSignature("wagmi"), values
         );
         vm.stopPrank();
     }
@@ -204,7 +187,7 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         uint64 nonce,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
         vm.assume(nonce != 0 && nonce < type(uint64).max);
         vm.setNonce(createXAddr, nonce);
@@ -213,12 +196,10 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         vm.deal(arg3, values.constructorAmount + values.initCallAmount);
         vm.startPrank(arg3);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            new bytes(0),
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
     }
@@ -227,10 +208,10 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
-        uint64 nonce,
-        CreateX.Values memory values
-    ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
+    function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(uint64 nonce, ICreateX.Values memory values)
+        external
+        whenTheInitCodeFailsToDeployARuntimeBytecode
+    {
         vm.assume(nonce != 0 && nonce < type(uint64).max);
         vm.setNonce(createXAddr, nonce);
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
@@ -238,16 +219,14 @@ contract CreateX_DeployCreateAndInit_3Args_Public_Test is BaseTest {
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         vm.deal(arg3, values.constructorAmount + values.initCallAmount);
         vm.startPrank(arg3);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            invalidInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
     }

--- a/test/public/CREATE/CreateX.deployCreateAndInit_4Args.t.sol
+++ b/test/public/CREATE/CreateX.deployCreateAndInit_4Args.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -34,7 +34,7 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         uint64 nonce,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     )
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
@@ -53,12 +53,9 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address as indexed argument.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         address newContract = createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
 
         assertEq(newContract, computedAddress, "100");
@@ -83,7 +80,7 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         uint64 nonce,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint256 amount
     )
         external
@@ -105,12 +102,9 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address as indexed argument.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         address newContract = createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
 
         assertEq(newContract, computedAddress, "100");
@@ -131,7 +125,7 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
         uint64 nonce,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint256 amount
     )
         external
@@ -145,17 +139,11 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedEtherTransfer.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            SELF
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, SELF
         );
     }
 
@@ -163,10 +151,7 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
-        uint64 nonce,
-        CreateX.Values memory values
-    )
+    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(uint64 nonce, ICreateX.Values memory values)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsUnsuccessful
@@ -176,17 +161,11 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeWithSignature("wagmi"),
-            values,
-            arg3
+            cachedInitCode, abi.encodeWithSignature("wagmi"), values, arg3
         );
     }
 
@@ -196,20 +175,17 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         uint64 nonce,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
         vm.assume(nonce != 0 && nonce < type(uint64).max);
         vm.setNonce(createXAddr, nonce);
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            new bytes(0),
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
     }
 
@@ -217,10 +193,10 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
-        uint64 nonce,
-        CreateX.Values memory values
-    ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
+    function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(uint64 nonce, ICreateX.Values memory values)
+        external
+        whenTheInitCodeFailsToDeployARuntimeBytecode
+    {
         vm.assume(nonce != 0 && nonce < type(uint64).max);
         vm.setNonce(createXAddr, nonce);
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
@@ -228,15 +204,12 @@ contract CreateX_DeployCreateAndInit_4Args_Public_Test is BaseTest {
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreateAndInit{value: values.constructorAmount + values.initCallAmount}(
-            invalidInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
     }
 }

--- a/test/public/CREATE/CreateX.deployCreateClone.t.sol
+++ b/test/public/CREATE/CreateX.deployCreateClone.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {ImplementationContract} from "../../mocks/ImplementationContract.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreateClone_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -41,21 +41,14 @@ contract CreateX_DeployCreateClone_Public_Test is BaseTest {
         // It emits the event `ContractCreation` with the EIP-1167 minimal proxy address as indexed argument.
         // It returns the EIP-1167 minimal proxy address.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         address proxy = createX.deployCreateClone{value: msgValue}(
-            implementation,
-            abi.encodeCall(implementationContract.initialiser, ())
+            implementation, abi.encodeCall(implementationContract.initialiser, ())
         );
         assertEq(proxy, computedAddress, "100");
         assertEq(
             proxy.codehash,
-            keccak256(
-                abi.encodePacked(
-                    hex"36_3d_3d_37_3d_3d_3d_36_3d_73",
-                    implementation,
-                    hex"5a_f4_3d_82_80_3e_90_3d_91_60_2b_57_fd_5b_f3"
-                )
-            ),
+            keccak256(abi.encodePacked(hex"363d3d373d3d3d363d73", implementation, hex"5af43d82803e903d91602b57fd5bf3")),
             "200"
         );
         assertTrue(!implementationContract.isInitialised(), "300");
@@ -68,10 +61,7 @@ contract CreateX_DeployCreateClone_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheEIP1167MinimalProxyInitialisationCallIsUnsuccessful(
-        uint64 nonce,
-        uint256 msgValue
-    )
+    function testFuzz_WhenTheEIP1167MinimalProxyInitialisationCallIsUnsuccessful(uint64 nonce, uint256 msgValue)
         external
         whenTheEIP1167MinimalProxyContractIsSuccessfullyCreated
         whenTheEIP1167MinimalProxyInitialisationCallIsUnsuccessful
@@ -80,15 +70,11 @@ contract CreateX_DeployCreateClone_Public_Test is BaseTest {
         vm.setNonce(createXAddr, nonce);
         msgValue = bound(msgValue, 0, type(uint64).max);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreateClone{value: msgValue}(
-            makeAddr("initialAccount"),
-            abi.encodeCall(implementationContract.initialiser, ())
+            makeAddr("initialAccount"), abi.encodeCall(implementationContract.initialiser, ())
         );
     }
 
@@ -96,10 +82,10 @@ contract CreateX_DeployCreateClone_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheEIP1167MinimalProxyContractCreationFails(
-        uint64 nonce,
-        uint256 msgValue
-    ) external whenTheEIP1167MinimalProxyContractCreationFails {
+    function testFuzz_WhenTheEIP1167MinimalProxyContractCreationFails(uint64 nonce, uint256 msgValue)
+        external
+        whenTheEIP1167MinimalProxyContractCreationFails
+    {
         vm.assume(nonce != 0 && nonce < type(uint64).max);
         vm.setNonce(createXAddr, nonce);
         msgValue = bound(msgValue, 0, type(uint64).max);
@@ -108,11 +94,10 @@ contract CreateX_DeployCreateClone_Public_Test is BaseTest {
         // To enforce a deployment failure, we add code to the destination address `proxy`.
         vm.etch(computedAddress, hex"01");
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreateClone{value: msgValue}(
-            implementation,
-            abi.encodeCall(implementationContract.initialiser, ())
+            implementation, abi.encodeCall(implementationContract.initialiser, ())
         );
     }
 }

--- a/test/public/CREATE2/CreateX.deployCreate2AndInit_3Args.t.sol
+++ b/test/public/CREATE2/CreateX.deployCreate2AndInit_3Args.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -45,7 +45,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint64 chainId,
         address msgSender
     )
@@ -57,24 +57,15 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -89,12 +80,10 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress, guardedSalt);
+        emit ICreateX.ContractCreation(computedAddress, guardedSalt);
         vm.startPrank(originalDeployer);
         address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
 
@@ -112,9 +101,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         vm.deal(msgSender, values.constructorAmount + values.initCallAmount);
         vm.startPrank(msgSender);
         newContractMsgSender = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -163,7 +150,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint64 chainId,
         address msgSender,
         uint256 amount
@@ -178,25 +165,16 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         assumePayable(originalDeployer);
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -211,12 +189,10 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress, guardedSalt);
+        emit ICreateX.ContractCreation(computedAddress, guardedSalt);
         vm.startPrank(originalDeployer);
         address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
 
@@ -236,9 +212,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         vm.deal(msgSender, values.constructorAmount + values.initCallAmount);
         vm.startPrank(msgSender);
         newContractMsgSender = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -284,10 +258,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
-        CreateX.Values memory values,
-        uint256 amount
-    )
+    function testFuzz_WhenTheRefundTransactionIsUnsuccessful(ICreateX.Values memory values, uint256 amount)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsSuccessful
@@ -300,25 +271,18 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         vm.startPrank(SELF);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            SELF,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(SELF, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(SELF);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedEtherTransfer.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
     }
@@ -327,10 +291,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         _;
     }
 
-    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
-        address originalDeployer,
-        CreateX.Values memory values
-    )
+    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(address originalDeployer, ICreateX.Values memory values)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsUnsuccessful
@@ -342,25 +303,18 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeWithSignature("wagmi"),
-            values
+            cachedInitCode, abi.encodeWithSignature("wagmi"), values
         );
         vm.stopPrank();
     }
@@ -371,7 +325,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         address originalDeployer,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
@@ -380,21 +334,17 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            new bytes(0),
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
     }
@@ -405,7 +355,7 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
         address originalDeployer,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
@@ -414,25 +364,21 @@ contract CreateX_DeployCreate2AndInit_3Args_Public_Test is BaseTest {
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            invalidInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values
+            invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
         );
         vm.stopPrank();
     }

--- a/test/public/CREATE2/CreateX.deployCreate2AndInit_4Args_CustomiseRefundAddress.t.sol
+++ b/test/public/CREATE2/CreateX.deployCreate2AndInit_4Args_CustomiseRefundAddress.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -45,7 +45,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint64 chainId,
         address msgSender
     )
@@ -57,24 +57,15 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -89,13 +80,10 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress, guardedSalt);
+        emit ICreateX.ContractCreation(computedAddress, guardedSalt);
         vm.startPrank(originalDeployer);
         address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
 
@@ -113,10 +101,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.deal(msgSender, values.constructorAmount + values.initCallAmount);
         vm.startPrank(msgSender);
         newContractMsgSender = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -165,7 +150,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint64 chainId,
         address msgSender,
         uint256 amount
@@ -180,24 +165,15 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -212,13 +188,10 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress, guardedSalt);
+        emit ICreateX.ContractCreation(computedAddress, guardedSalt);
         vm.startPrank(originalDeployer);
         address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
 
@@ -238,10 +211,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.deal(msgSender, values.constructorAmount + values.initCallAmount);
         vm.startPrank(msgSender);
         newContractMsgSender = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -287,10 +257,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         _;
     }
 
-    function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
-        CreateX.Values memory values,
-        uint256 amount
-    )
+    function testFuzz_WhenTheRefundTransactionIsUnsuccessful(ICreateX.Values memory values, uint256 amount)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsSuccessful
@@ -303,26 +270,18 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(SELF);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            SELF,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(SELF, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(SELF);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedEtherTransfer.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            SELF
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, SELF
         );
         vm.stopPrank();
     }
@@ -331,10 +290,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         _;
     }
 
-    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
-        address originalDeployer,
-        CreateX.Values memory values
-    )
+    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(address originalDeployer, ICreateX.Values memory values)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsUnsuccessful
@@ -346,26 +302,18 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeWithSignature("wagmi"),
-            values,
-            arg3
+            cachedInitCode, abi.encodeWithSignature("wagmi"), values, arg3
         );
         vm.stopPrank();
     }
@@ -376,7 +324,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         address originalDeployer,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
@@ -385,22 +333,17 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            new bytes(0),
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
     }
@@ -411,7 +354,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
         address originalDeployer,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
@@ -420,26 +363,21 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-            invalidInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
     }

--- a/test/public/CREATE2/CreateX.deployCreate2AndInit_4Args_CustomiseSalt.t.sol
+++ b/test/public/CREATE2/CreateX.deployCreate2AndInit_4Args_CustomiseSalt.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -46,7 +46,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId,
         address msgSender
@@ -59,13 +59,8 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         snapshotId = vm.snapshot();
 
@@ -77,22 +72,15 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
 
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         } else {
@@ -106,13 +94,10 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
             // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
             // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
             vm.expectEmit(true, true, true, true, createXAddr);
-            emit CreateX.ContractCreation(computedAddress, guardedSalt);
+            emit ICreateX.ContractCreation(computedAddress, guardedSalt);
             vm.startPrank(originalDeployer);
             address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
 
@@ -229,7 +214,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId,
         address msgSender
@@ -245,13 +230,8 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         assumePayable(originalDeployer);
         snapshotId = vm.snapshot();
@@ -264,22 +244,15 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
 
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         } else {
@@ -293,13 +266,10 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
             // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
             // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
             vm.expectEmit(true, true, true, true, createXAddr);
-            emit CreateX.ContractCreation(computedAddress, guardedSalt);
+            emit ICreateX.ContractCreation(computedAddress, guardedSalt);
             vm.startPrank(originalDeployer);
             address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
 
@@ -357,9 +327,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
                 // Since everything was returned in the previous call, the balance must be equal to the original
                 // refund amount.
                 assertEq(
-                    originalDeployer.balance,
-                    cachedBalance + values.constructorAmount + values.initCallAmount,
-                    "2400"
+                    originalDeployer.balance, cachedBalance + values.constructorAmount + values.initCallAmount, "2400"
                 );
                 assertEq(ERC20MockPayable(newContractMsgSender).name(), arg1, "2500");
                 assertEq(ERC20MockPayable(newContractMsgSender).symbol(), arg2, "2600");
@@ -391,9 +359,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
                 assertEq(createXAddr.balance, 0, "3300");
                 // It returns the non-zero balance to the `msg.sender` address.
                 assertEq(
-                    originalDeployer.balance,
-                    cachedBalance + values.constructorAmount + values.initCallAmount,
-                    "3400"
+                    originalDeployer.balance, cachedBalance + values.constructorAmount + values.initCallAmount, "3400"
                 );
                 assertEq(ERC20MockPayable(newContractOriginalDeployer).name(), arg1, "3500");
                 assertEq(ERC20MockPayable(newContractOriginalDeployer).symbol(), arg2, "3600");
@@ -429,7 +395,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
     }
 
     function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     )
@@ -452,32 +418,23 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(SELF, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(SELF, salt);
         if (mustRevert) {
             vm.startPrank(SELF);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         } else {
             vm.startPrank(SELF);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(
-                CreateX.FailedEtherTransfer.selector,
-                createXAddr,
-                new bytes(0)
-            );
+            bytes memory expectedErr =
+                abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         }
@@ -489,7 +446,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
 
     function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     )
@@ -501,10 +458,8 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress
         );
         // Helper logic to increase the probability of matching a permissioned deploy protection during fuzzing.
         if (chainId % 2 == 0) {
@@ -514,32 +469,23 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(originalDeployer, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeWithSignature("wagmi"),
-                values
+                salt, cachedInitCode, abi.encodeWithSignature("wagmi"), values
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(
-                CreateX.FailedContractInitialisation.selector,
-                createXAddr,
-                new bytes(0)
-            );
+            bytes memory expectedErr =
+                abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeWithSignature("wagmi"),
-                values
+                salt, cachedInitCode, abi.encodeWithSignature("wagmi"), values
             );
             vm.stopPrank();
         }
@@ -551,7 +497,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
@@ -559,10 +505,8 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress
         );
         // Helper logic to increase the probability of matching a permissioned deploy protection during fuzzing.
         if (chainId % 2 == 0) {
@@ -572,28 +516,22 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(originalDeployer, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                new bytes(0),
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                new bytes(0),
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         }
@@ -605,7 +543,7 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
 
     function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
@@ -613,10 +551,8 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress
         );
         // Helper logic to increase the probability of matching a permissioned deploy protection during fuzzing.
         if (chainId % 2 == 0) {
@@ -626,32 +562,26 @@ contract CreateX_DeployCreate2AndInit_4Args_CustomiseSalt_Public_Test is BaseTes
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(originalDeployer, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                invalidInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                invalidInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values
+                salt, invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values
             );
             vm.stopPrank();
         }

--- a/test/public/CREATE2/CreateX.deployCreate2AndInit_5Args.t.sol
+++ b/test/public/CREATE2/CreateX.deployCreate2AndInit_5Args.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -46,7 +46,7 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId,
         address msgSender
@@ -59,13 +59,8 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         snapshotId = vm.snapshot();
 
@@ -77,23 +72,15 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
 
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
         } else {
@@ -107,14 +94,10 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
             // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
             // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
             vm.expectEmit(true, true, true, true, createXAddr);
-            emit CreateX.ContractCreation(computedAddress, guardedSalt);
+            emit ICreateX.ContractCreation(computedAddress, guardedSalt);
             vm.startPrank(originalDeployer);
             address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
 
@@ -231,7 +214,7 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId,
         address msgSender
@@ -247,13 +230,8 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         snapshotId = vm.snapshot();
 
@@ -265,23 +243,15 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
 
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
         } else {
@@ -295,14 +265,10 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
             // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
             // It emits the event `ContractCreation` with the contract address and the salt as indexed arguments.
             vm.expectEmit(true, true, true, true, createXAddr);
-            emit CreateX.ContractCreation(computedAddress, guardedSalt);
+            emit ICreateX.ContractCreation(computedAddress, guardedSalt);
             vm.startPrank(originalDeployer);
             address newContract = createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
 
@@ -425,7 +391,7 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
     }
 
     function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     )
@@ -448,34 +414,23 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(SELF, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(SELF, salt);
         if (mustRevert) {
             vm.startPrank(SELF);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                SELF
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, SELF
             );
             vm.stopPrank();
         } else {
             vm.startPrank(SELF);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(
-                CreateX.FailedEtherTransfer.selector,
-                createXAddr,
-                new bytes(0)
-            );
+            bytes memory expectedErr =
+                abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                SELF
+                salt, cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, SELF
             );
             vm.stopPrank();
         }
@@ -487,7 +442,7 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     )
@@ -499,10 +454,8 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress
         );
         // Helper logic to increase the probability of matching a permissioned deploy protection during fuzzing.
         if (chainId % 2 == 0) {
@@ -512,34 +465,23 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(originalDeployer, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeWithSignature("wagmi"),
-                values,
-                arg3
+                salt, cachedInitCode, abi.encodeWithSignature("wagmi"), values, arg3
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(
-                CreateX.FailedContractInitialisation.selector,
-                createXAddr,
-                new bytes(0)
-            );
+            bytes memory expectedErr =
+                abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                cachedInitCode,
-                abi.encodeWithSignature("wagmi"),
-                values,
-                arg3
+                salt, cachedInitCode, abi.encodeWithSignature("wagmi"), values, arg3
             );
             vm.stopPrank();
         }
@@ -551,7 +493,7 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
@@ -559,10 +501,8 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress
         );
         // Helper logic to increase the probability of matching a permissioned deploy protection during fuzzing.
         if (chainId % 2 == 0) {
@@ -572,30 +512,22 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(originalDeployer, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                new bytes(0),
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                new bytes(0),
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
         }
@@ -607,7 +539,7 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
 
     function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         bytes32 salt,
         uint64 chainId
     ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
@@ -615,10 +547,8 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress
         );
         // Helper logic to increase the probability of matching a permissioned deploy protection during fuzzing.
         if (chainId % 2 == 0) {
@@ -628,34 +558,26 @@ contract CreateX_DeployCreate2AndInit_5Args_Public_Test is BaseTest {
         if (chainId % 3 == 0) {
             salt = bytes32(abi.encodePacked(bytes20(salt), hex"01", bytes11(uint88(uint256(salt)))));
         }
-        (, , bool mustRevert, ) = parseFuzzerSalt(originalDeployer, salt);
+        (,, bool mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                invalidInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2AndInit{value: values.constructorAmount + values.initCallAmount}(
-                salt,
-                invalidInitCode,
-                abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-                values,
-                arg3
+                salt, invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
             );
             vm.stopPrank();
         }

--- a/test/public/CREATE2/CreateX.deployCreate2Clone_2Args.t.sol
+++ b/test/public/CREATE2/CreateX.deployCreate2Clone_2Args.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {ImplementationContract} from "../../mocks/ImplementationContract.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -13,13 +13,7 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
     ImplementationContract internal implementationContract = new ImplementationContract();
     address internal implementation = address(implementationContract);
     bytes32 internal codeHash =
-        keccak256(
-            abi.encodePacked(
-                hex"36_3d_3d_37_3d_3d_3d_36_3d_73",
-                implementation,
-                hex"5a_f4_3d_82_80_3e_90_3d_91_60_2b_57_fd_5b_f3"
-            )
-        );
+        keccak256(abi.encodePacked(hex"363d3d373d3d3d363d73", implementation, hex"5af43d82803e903d91602b57fd5bf3"));
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                            TESTS                           */
@@ -29,9 +23,7 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         BaseTest.setUp();
         initCodeHash = keccak256(
             abi.encodePacked(
-                hex"3d_60_2d_80_60_0a_3d_39_81_f3_36_3d_3d_37_3d_3d_3d_36_3d_73",
-                implementation,
-                hex"5a_f4_3d_82_80_3e_90_3d_91_60_2b_57_fd_5b_f3"
+                hex"3d602d80600a3d3981f3363d3d373d3d3d363d73", implementation, hex"5af43d82803e903d91602b57fd5bf3"
             )
         );
     }
@@ -57,26 +49,16 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         msgValue = bound(msgValue, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * msgValue);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != implementation &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != implementation &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != implementation && originalDeployer != zeroAddress && msgSender != createXAddr
+                && msgSender != implementation && msgSender != zeroAddress
         );
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -88,12 +70,10 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         // It emits the event `ContractCreation` with the EIP-1167 minimal proxy address and the salt as indexed arguments.
         // It returns the EIP-1167 minimal proxy address.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress, guardedSalt);
+        emit ICreateX.ContractCreation(computedAddress, guardedSalt);
         vm.startPrank(originalDeployer);
         address proxy = createX.deployCreate2Clone{value: msgValue}(
-            salt,
-            implementation,
-            abi.encodeCall(implementationContract.initialiser, ())
+            salt, implementation, abi.encodeCall(implementationContract.initialiser, ())
         );
         vm.stopPrank();
 
@@ -109,8 +89,7 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         vm.deal(msgSender, msgValue);
         vm.startPrank(msgSender);
         address newContractMsgSender = createX.deployCreate2Clone{value: msgValue}(
-            implementation,
-            abi.encodeCall(implementationContract.initialiser, ())
+            implementation, abi.encodeCall(implementationContract.initialiser, ())
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -127,8 +106,7 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         // We mock the original caller.
         vm.startPrank(originalDeployer);
         address newContractOriginalDeployer = createX.deployCreate2Clone{value: msgValue}(
-            implementation,
-            abi.encodeCall(implementationContract.initialiser, ())
+            implementation, abi.encodeCall(implementationContract.initialiser, ())
         );
         vm.stopPrank();
         vm.assume(originalDeployer != newContractOriginalDeployer);
@@ -159,36 +137,28 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         msgValue = bound(msgValue, 0, type(uint64).max);
         vm.deal(originalDeployer, msgValue);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != implementation &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != implementation && originalDeployer != zeroAddress
         );
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert,) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2Clone{value: msgValue}(implementation, abi.encodeWithSignature("wagmi"));
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(
-                CreateX.FailedContractInitialisation.selector,
-                createXAddr,
-                new bytes(0)
-            );
+            bytes memory expectedErr =
+                abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
             vm.expectRevert(expectedErr);
             createX.deployCreate2Clone{value: msgValue}(implementation, abi.encodeWithSignature("wagmi"));
             vm.stopPrank();
@@ -207,21 +177,14 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         msgValue = bound(msgValue, 0, type(uint64).max);
         vm.deal(originalDeployer, msgValue);
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != createXAddr &&
-                originalDeployer != implementation &&
-                originalDeployer != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != createXAddr
+                && originalDeployer != implementation && originalDeployer != zeroAddress
         );
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (
-            bool permissionedDeployProtection,
-            bool xChainRedeployProtection,
-            bool mustRevert,
-            bytes32 guardedSalt
-        ) = parseFuzzerSalt(originalDeployer, salt);
+        (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -231,21 +194,19 @@ contract CreateX_DeployCreate2Clone_2Args_Public_Test is BaseTest {
         vm.etch(computedAddress, hex"01");
         if (mustRevert) {
             vm.startPrank(originalDeployer);
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.InvalidSalt.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.InvalidSalt.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2Clone{value: msgValue}(
-                implementation,
-                abi.encodeCall(implementationContract.initialiser, ())
+                implementation, abi.encodeCall(implementationContract.initialiser, ())
             );
             vm.stopPrank();
         } else {
             vm.startPrank(originalDeployer);
             // It should revert.
-            bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+            bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
             vm.expectRevert(expectedErr);
             createX.deployCreate2Clone{value: msgValue}(
-                implementation,
-                abi.encodeCall(implementationContract.initialiser, ())
+                implementation, abi.encodeCall(implementationContract.initialiser, ())
             );
             vm.stopPrank();
         }

--- a/test/public/CREATE3/CreateX.deployCreate3AndInit_4Args_CustomiseRefundAddress.t.sol
+++ b/test/public/CREATE3/CreateX.deployCreate3AndInit_4Args_CustomiseRefundAddress.t.sol
@@ -5,7 +5,7 @@ import {Vm} from "forge-std/Vm.sol";
 import {BaseTest} from "../../utils/BaseTest.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 import {ERC20MockPayable} from "../../mocks/ERC20MockPayable.sol";
-import {CreateX} from "../../../src/CreateX.sol";
+import {ICreateX, CreateX} from "../../../src/CreateX.sol";
 
 contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test is BaseTest {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
@@ -13,8 +13,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     // The `keccak256`-hashed `CREATE3` proxy contract creation bytecode.
-    bytes32 internal proxyInitCodeHash =
-        keccak256(abi.encodePacked(hex"67_36_3d_3d_37_36_3d_34_f0_3d_52_60_08_60_18_f3"));
+    bytes32 internal proxyInitCodeHash = keccak256(abi.encodePacked(hex"67363d3d37363d34f03d5260086018f3"));
 
     // To avoid any stack-too-deep errors, we use `internal` state variables for the precomputed `CREATE3` address
     // and some further contract deployment addresses and variables.
@@ -54,7 +53,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLengthAndWhenTheInitialisationCallIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint64 chainId,
         address msgSender
     )
@@ -66,23 +65,16 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         snapshotId = vm.snapshot();
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, guardedSalt) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -98,20 +90,17 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         // We record the emitted events to later assert the proxy contract address.
         vm.recordLogs();
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
+        emit ICreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
         // We also check for the ERC-20 standard `Transfer` event.
         vm.expectEmit(true, true, true, true, computedAddress);
         emit IERC20.Transfer(zeroAddress, arg3, arg4);
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address as indexed argument.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         vm.startPrank(originalDeployer);
         address newContract = createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
 
@@ -130,21 +119,18 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(msgSender);
         salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (, , , guardedSalt) = parseFuzzerSalt(msgSender, salt);
+        (,,, guardedSalt) = parseFuzzerSalt(msgSender, salt);
         proxyAddress = createX.computeCreate2Address(guardedSalt, proxyInitCodeHash, createXAddr);
         vm.assume(msgSender != proxyAddress);
         // We record the emitted events to later assert the proxy contract address.
         vm.recordLogs();
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
+        emit ICreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
         // We mock a potential frontrunner address.
         vm.deal(msgSender, values.constructorAmount + values.initCallAmount);
         vm.startPrank(msgSender);
         newContractMsgSender = createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -171,11 +157,11 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (, , , guardedSalt) = parseFuzzerSalt(originalDeployer, salt);
+        (,,, guardedSalt) = parseFuzzerSalt(originalDeployer, salt);
         proxyAddress = createX.computeCreate2Address(guardedSalt, proxyInitCodeHash, createXAddr);
         vm.assume(originalDeployer != proxyAddress);
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
+        emit ICreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
         // We mock the original caller.
         vm.startPrank(originalDeployer);
         newContractOriginalDeployer = createX.deployCreate3AndInit{
@@ -212,7 +198,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheCreateXContractHasANonZeroBalanceAndWhenTheRefundTransactionIsSuccessful(
         address originalDeployer,
-        CreateX.Values memory values,
+        ICreateX.Values memory values,
         uint64 chainId,
         address msgSender
     )
@@ -227,23 +213,16 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, 2 * (values.constructorAmount + values.initCallAmount));
         vm.assume(
-            chainId != block.chainid &&
-                chainId != 0 &&
-                originalDeployer != msgSender &&
-                originalDeployer != createXAddr &&
-                originalDeployer != zeroAddress &&
-                msgSender != createXAddr &&
-                msgSender != zeroAddress
+            chainId != block.chainid && chainId != 0 && originalDeployer != msgSender && originalDeployer != createXAddr
+                && originalDeployer != zeroAddress && msgSender != createXAddr && msgSender != zeroAddress
         );
         snapshotId = vm.snapshot();
 
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, guardedSalt) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -259,20 +238,17 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         // We record the emitted events to later assert the proxy contract address.
         vm.recordLogs();
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
+        emit ICreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
         // We also check for the ERC-20 standard `Transfer` event.
         vm.expectEmit(true, true, true, true, computedAddress);
         emit IERC20.Transfer(zeroAddress, arg3, arg4);
         // It returns a contract address with a non-zero bytecode length and a potential non-zero ether balance.
         // It emits the event `ContractCreation` with the contract address as indexed argument.
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.ContractCreation(computedAddress);
+        emit ICreateX.ContractCreation(computedAddress);
         vm.startPrank(originalDeployer);
         address newContract = createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
 
@@ -293,21 +269,18 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(msgSender);
         salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (, , , guardedSalt) = parseFuzzerSalt(msgSender, salt);
+        (,,, guardedSalt) = parseFuzzerSalt(msgSender, salt);
         proxyAddress = createX.computeCreate2Address(guardedSalt, proxyInitCodeHash, createXAddr);
         vm.assume(msgSender != proxyAddress);
         // We record the emitted events to later assert the proxy contract address.
         vm.recordLogs();
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
+        emit ICreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
         // We mock a potential frontrunner address.
         vm.deal(msgSender, values.constructorAmount + values.initCallAmount);
         vm.startPrank(msgSender);
         newContractMsgSender = createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
         vm.assume(msgSender != newContractMsgSender);
@@ -337,11 +310,11 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (, , , guardedSalt) = parseFuzzerSalt(originalDeployer, salt);
+        (,,, guardedSalt) = parseFuzzerSalt(originalDeployer, salt);
         proxyAddress = createX.computeCreate2Address(guardedSalt, proxyInitCodeHash, createXAddr);
         vm.assume(originalDeployer != proxyAddress);
         vm.expectEmit(true, true, true, true, createXAddr);
-        emit CreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
+        emit ICreateX.Create3ProxyContractCreation(proxyAddress, guardedSalt);
         // We mock the original caller.
         vm.startPrank(originalDeployer);
         newContractOriginalDeployer = createX.deployCreate3AndInit{
@@ -372,10 +345,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         _;
     }
 
-    function testFuzz_WhenTheRefundTransactionIsUnsuccessful(
-        CreateX.Values memory values,
-        uint256 amount
-    )
+    function testFuzz_WhenTheRefundTransactionIsUnsuccessful(ICreateX.Values memory values, uint256 amount)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsSuccessful
@@ -388,23 +358,17 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(SELF);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, ) = parseFuzzerSalt(SELF, salt);
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert,) = parseFuzzerSalt(SELF, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(SELF);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedEtherTransfer.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedEtherTransfer.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            SELF
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, SELF
         );
         vm.stopPrank();
     }
@@ -413,10 +377,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         _;
     }
 
-    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(
-        address originalDeployer,
-        CreateX.Values memory values
-    )
+    function testFuzz_WhenTheInitialisationCallIsUnsuccessful(address originalDeployer, ICreateX.Values memory values)
         external
         whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithANonZeroLength
         whenTheInitialisationCallIsUnsuccessful
@@ -428,26 +389,17 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(
-            CreateX.FailedContractInitialisation.selector,
-            createXAddr,
-            new bytes(0)
-        );
+        bytes memory expectedErr =
+            abi.encodeWithSelector(ICreateX.FailedContractInitialisation.selector, createXAddr, new bytes(0));
         vm.expectRevert(expectedErr);
         createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeWithSignature("wagmi"),
-            values,
-            arg3
+            cachedInitCode, abi.encodeWithSignature("wagmi"), values, arg3
         );
         vm.stopPrank();
     }
@@ -456,10 +408,10 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         _;
     }
 
-    function testFuzz_WhenTheProxyContractCreationFails(
-        address originalDeployer,
-        CreateX.Values memory values
-    ) external whenTheProxyContractCreationFails {
+    function testFuzz_WhenTheProxyContractCreationFails(address originalDeployer, ICreateX.Values memory values)
+        external
+        whenTheProxyContractCreationFails
+    {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
         vm.deal(originalDeployer, values.constructorAmount + values.initCallAmount);
@@ -467,10 +419,8 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, guardedSalt) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, guardedSalt) =
+            parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
@@ -480,13 +430,10 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.etch(computedAddress, hex"01");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            cachedInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            cachedInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
     }
@@ -497,7 +444,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(
         address originalDeployer,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
@@ -506,22 +453,16 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            new bytes(0),
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            new bytes(0), abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
     }
@@ -532,7 +473,7 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
 
     function testFuzz_WhenTheInitCodeFailsToDeployARuntimeBytecode(
         address originalDeployer,
-        CreateX.Values memory values
+        ICreateX.Values memory values
     ) external whenTheInitCodeFailsToDeployARuntimeBytecode {
         values.constructorAmount = bound(values.constructorAmount, 0, type(uint64).max);
         values.initCallAmount = bound(values.initCallAmount, 0, type(uint64).max);
@@ -541,26 +482,20 @@ contract CreateX_DeployCreate3AndInit_4Args_CustomiseRefundAddress_Public_Test i
         vm.startPrank(originalDeployer);
         bytes32 salt = createXHarness.exposed_generateSalt();
         vm.stopPrank();
-        (permissionedDeployProtection, xChainRedeployProtection, mustRevert, ) = parseFuzzerSalt(
-            originalDeployer,
-            salt
-        );
+        (permissionedDeployProtection, xChainRedeployProtection, mustRevert,) = parseFuzzerSalt(originalDeployer, salt);
         // When we pseudo-randomly calculate the salt value `salt`, we must never have configured a permissioned
         // deploy protection or a cross-chain redeploy protection, and it must never revert.
         assertTrue(!permissionedDeployProtection && !xChainRedeployProtection && !mustRevert, "100");
         // The following contract creation code contains the invalid opcode `PUSH0` (`0x5F`) and `CREATE` must therefore
         // return the zero address (technically zero bytes `0x`), as the deployment fails. This test also ensures that if
         // we ever accidentally change the EVM version in Foundry and Hardhat, we will always have a corresponding failed test.
-        bytes memory invalidInitCode = hex"5f_80_60_09_3d_39_3d_f3";
+        bytes memory invalidInitCode = hex"5f8060093d393df3";
         vm.startPrank(originalDeployer);
         // It should revert.
-        bytes memory expectedErr = abi.encodeWithSelector(CreateX.FailedContractCreation.selector, createXAddr);
+        bytes memory expectedErr = abi.encodeWithSelector(ICreateX.FailedContractCreation.selector, createXAddr);
         vm.expectRevert(expectedErr);
         createX.deployCreate3AndInit{value: values.constructorAmount + values.initCallAmount}(
-            invalidInitCode,
-            abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)),
-            values,
-            arg3
+            invalidInitCode, abi.encodeCall(ERC20MockPayable.mint, (arg3, arg4)), values, arg3
         );
         vm.stopPrank();
     }

--- a/test/utils/BaseTest.sol
+++ b/test/utils/BaseTest.sol
@@ -12,9 +12,11 @@ contract CreateXHarness is CreateX {
         guardedSalt = _guard(salt);
     }
 
-    function exposed_parseSalt(
-        bytes32 salt
-    ) external view returns (SenderBytes senderBytes, RedeployProtectionFlag redeployProtectionFlag) {
+    function exposed_parseSalt(bytes32 salt)
+        external
+        view
+        returns (SenderBytes senderBytes, RedeployProtectionFlag redeployProtectionFlag)
+    {
         (senderBytes, redeployProtectionFlag) = _parseSalt(salt);
     }
 
@@ -117,21 +119,18 @@ contract BaseTest is Test {
      * @return mustRevert The Boolean variable that specifies whether it must revert.
      * @return guardedSalt The guarded 32-byte random value used to create the contract address.
      */
-    function parseFuzzerSalt(
-        address originalDeployer,
-        bytes32 salt
-    )
+    function parseFuzzerSalt(address originalDeployer, bytes32 salt)
         internal
         returns (bool permissionedDeployProtection, bool xChainRedeployProtection, bool mustRevert, bytes32 guardedSalt)
     {
         vm.startPrank(originalDeployer);
-        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) = createXHarness
-            .exposed_parseSalt(salt);
+        (CreateX.SenderBytes senderBytes, CreateX.RedeployProtectionFlag redeployProtectionFlag) =
+            createXHarness.exposed_parseSalt(salt);
         vm.stopPrank();
 
         if (
-            senderBytes == CreateX.SenderBytes.MsgSender &&
-            redeployProtectionFlag == CreateX.RedeployProtectionFlag.True
+            senderBytes == CreateX.SenderBytes.MsgSender
+                && redeployProtectionFlag == CreateX.RedeployProtectionFlag.True
         ) {
             vm.startPrank(originalDeployer);
             // Configures a permissioned deploy protection as well as a cross-chain redeploy protection.
@@ -140,8 +139,8 @@ contract BaseTest is Test {
             permissionedDeployProtection = true;
             xChainRedeployProtection = true;
         } else if (
-            senderBytes == CreateX.SenderBytes.MsgSender &&
-            redeployProtectionFlag == CreateX.RedeployProtectionFlag.False
+            senderBytes == CreateX.SenderBytes.MsgSender
+                && redeployProtectionFlag == CreateX.RedeployProtectionFlag.False
         ) {
             vm.startPrank(originalDeployer);
             // Configures solely a permissioned deploy protection.
@@ -152,8 +151,8 @@ contract BaseTest is Test {
             // Reverts if the 21st byte is greater than `0x01` in order to enforce developer explicitness.
             mustRevert = true;
         } else if (
-            senderBytes == CreateX.SenderBytes.ZeroAddress &&
-            redeployProtectionFlag == CreateX.RedeployProtectionFlag.True
+            senderBytes == CreateX.SenderBytes.ZeroAddress
+                && redeployProtectionFlag == CreateX.RedeployProtectionFlag.True
         ) {
             vm.startPrank(originalDeployer);
             // Configures solely a cross-chain redeploy protection.
@@ -161,8 +160,8 @@ contract BaseTest is Test {
             vm.stopPrank();
             xChainRedeployProtection = true;
         } else if (
-            senderBytes == CreateX.SenderBytes.ZeroAddress &&
-            redeployProtectionFlag == CreateX.RedeployProtectionFlag.Unspecified
+            senderBytes == CreateX.SenderBytes.ZeroAddress
+                && redeployProtectionFlag == CreateX.RedeployProtectionFlag.Unspecified
         ) {
             // Reverts if the 21st byte is greater than `0x01` in order to enforce developer explicitness.
             mustRevert = true;


### PR DESCRIPTION
<!--
Thank you for using CreateX and taking the time to send a pull request (PR)!

If you are introducing a new feature, please discuss it in an issue or in the discussions section before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

#### PR Checklist

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed in an [issue](https://github.com/pcaversaccio/createx/issues) or in the [discussions](https://github.com/pcaversaccio/createx/discussions) section.
- [x] I didn't do anything of this.

---

<!-- Add a description of your PR here -->

In the `CreateX.sol` and `ICreateX.sol` files, events, errors, and the `Values` struct are currently defined separately. While a diff check of ABIs is part of the CI workflow [as seen in this PR](https://github.com/pcaversaccio/createx/pull/22/commits/d87c05e5634ba13918a9946906553e1234bd998c#diff-3ea54af4839eb75404d71b28252bead7e7ec8f676b1f815e1cde02629a75c165), explicitly inheriting the interface or defining `ICreateX.sol` as an abstract contract within the `CreateX `contract would ensure alignment and eliminate any discrepancies.

---

#### 🐶 Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/pcaversaccio/createx/assets/10935300/507a49a8-60b3-4cf9-a88f-93c34aa68cb3)
