### PR TITLE
➕ Add OP-Endurance Test Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2233,6 +2233,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [LUKSO Testnet](https://explorer.execution.testnet.lukso.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Manta Pacific Testnet](https://pacific-explorer.testnet.manta.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Frame Testnet](https://explorer.testnet.frame.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [OP-Endurance Testnet](https://explorer-l2-testnet.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -427,5 +427,12 @@
     "urls": [
       "https://explorer.testnet.frame.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
+  },
+  {
+    "name": "OP-Endurance Testnet",
+    "chainId": 6480001001,
+    "urls": [
+      "https://explorer-l2-testnet.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -432,6 +432,14 @@ const config: HardhatUserConfig = {
       url: vars.get("FRAME_TESTNET_URL", "https://rpc.testnet.frame.xyz/http"),
       accounts,
     },
+    openduranceTestnet: {
+      chainId: 6480001001,
+      url: vars.get(
+        "OPENDURANCE_TESTNET_URL",
+        "https://rpc-l2-testnet.fusionist.io",
+      ),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -551,6 +559,8 @@ const config: HardhatUserConfig = {
       mantaTestnet: vars.get("MANTA_API_KEY", ""),
       // For Arthera testnet
       artheraTestnet: vars.get("ARTHERA_API_KEY", ""),
+      // For OP-Endurance testnet
+      openduranceTestnet: vars.get("OPENDURANCE_API_KEY", ""),
     },
     customChains: [
       {
@@ -857,6 +867,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://explorer-test.arthera.net/api",
           browserURL: "https://explorer-test.arthera.net",
+        },
+      },
+      {
+        network: "openduranceTestnet",
+        chainId: 6480001001,
+        urls: {
+          apiURL: "https://explorer-l2-testnet.fusionist.io/api",
+          browserURL: "https://explorer-l2-testnet.fusionist.io",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "deploy:shardeumtestnet": "npx hardhat run --no-compile --network shardeumTestnet scripts/deploy.ts",
     "deploy:artheratestnet": "npx hardhat run --no-compile --network artheraTestnet scripts/deploy.ts",
     "deploy:frametestnet": "npx hardhat run --no-compile --network frameTestnet scripts/deploy.ts",
+    "deploy:opendurancetestnet": "npx hardhat run --no-compile --network openduranceTestnet scripts/deploy.ts",
     "prettier:check": "npx prettier -c **/*.{js,ts,md,sol,json,yml,yaml}",
     "prettier:check:interface": "cd interface && pnpm prettier:check",
     "prettier:fix": "npx prettier -w **/*.{js,ts,md,sol,json,yml,yaml}",


### PR DESCRIPTION
### 🕓 Changelog

Add OP-Endurance test network deployment: [`0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`](https://explorer-l2-testnet.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed). Closes #74.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/cc670f26-7e65-469a-b7a4-b462abf6ac00)