### PR TITLE
♻️ Restrict Visibility Modifiers in Tests

### DIFF
--- a/test/internal/CreateX._efficientHash.t.sol
+++ b/test/internal/CreateX._efficientHash.t.sol
@@ -8,7 +8,7 @@ contract CreateX_EfficientHash_Internal_Test is BaseTest {
     /*                            TESTS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    function testFuzz_MatchesTheOutputOfAHighLevelHashAndShouldNeverRevert(bytes32 a, bytes32 b) external {
+    function testFuzz_MatchesTheOutputOfAHighLevelHashAndShouldNeverRevert(bytes32 a, bytes32 b) external view {
         // It should match the output of a high-level hash.
         // It should never revert.
         bytes32 expected = keccak256(abi.encodePacked(a, b));

--- a/test/invariants/CreateX_Invariants.t.sol
+++ b/test/invariants/CreateX_Invariants.t.sol
@@ -32,7 +32,7 @@ contract CreateX_Invariants is Test {
     /*                            TESTS                           */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    function statefulFuzz_EtherBalance() external {
+    function statefulFuzz_EtherBalance() external view {
         assertEq(createXAddr.balance, createXHandler.updatedBalance(), "100");
     }
 }


### PR DESCRIPTION
### 🕓 Changelog

Due to the `forge-std` release [`v1.8.0`](https://github.com/foundry-rs/forge-std/releases/tag/v1.8.0) that, amongst others, replaces `forge-std` Solidity code with native cheat code assertions from Foundry, we can restrict certain visibility modifiers in the test suite to `view`.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/snekmate/assets/25297591/0103b528-2b8b-401d-9773-8ce1fa13a4d9)