### PR TITLE
♻️ Fix `assume` Condition in `testFuzz_ShouldBeAFunctionOfMultipleBlockPropertiesAndTheCaller`

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -98,7 +98,7 @@ CreateX_DeployCreate_Public_Test:testFuzz_WhenTheInitCodeSuccessfullyCreatesARun
 CreateX_DeployCreate_Public_Test:testFuzz_WhenTheInitCodeSuccessfullyCreatesARuntimeBytecodeWithAZeroLength(uint64,uint256) (runs: 256, μ: 52370, ~: 52406)
 CreateX_EfficientHash_Internal_Test:testFuzz_MatchesTheOutputOfAHighLevelHashAndShouldNeverRevert(bytes32,bytes32) (runs: 256, μ: 9167, ~: 9167)
 CreateX_GenerateSalt_Internal_Test:testFuzz_NeverReverts(uint256) (runs: 256, μ: 19073, ~: 19073)
-CreateX_GenerateSalt_Internal_Test:testFuzz_ShouldBeAFunctionOfMultipleBlockPropertiesAndTheCaller(uint256,address,string,uint64,address) (runs: 256, μ: 62617, ~: 62382)
+CreateX_GenerateSalt_Internal_Test:testFuzz_ShouldBeAFunctionOfMultipleBlockPropertiesAndTheCaller(uint256,address,string,uint64,address) (runs: 256, μ: 60472, ~: 60279)
 CreateX_Guard_Internal_Test:testFuzz_WhenTheFirst20BytesOfTheSaltDoNotEqualTheCallerOrTheZeroAddress(address,bytes32) (runs: 256, μ: 33848, ~: 33849)
 CreateX_Guard_Internal_Test:testFuzz_WhenTheFirst20BytesOfTheSaltDoNotEqualTheCallerOrTheZeroAddressAndWhenTheSaltValueIsGeneratedPseudorandomly(address,uint256,address,string,uint64) (runs: 256, μ: 41608, ~: 41372)
 CreateX_Guard_Internal_Test:testFuzz_WhenTheFirst20BytesOfTheSaltEqualsTheCallerAndWhenThe21stByteOfTheSaltEquals0x00(address,bytes32) (runs: 256, μ: 33276, ~: 33276)

--- a/test/internal/CreateX._generateSalt.t.sol
+++ b/test/internal/CreateX._generateSalt.t.sol
@@ -41,9 +41,7 @@ contract CreateX_GenerateSalt_Internal_Test is BaseTest {
         // We test their dependencies by determining the current salt, changing any of those
         // values, and verifying that the salt changes.
         increment = bound(increment, 1, type(uint128).max);
-        vm.assume(
-            coinbase != zeroAddress && chainId != block.chainid && chainId != 0 && msgSender != createXHarnessAddr
-        );
+        vm.assume(coinbase != zeroAddress && chainId != block.chainid && chainId != 0 && msgSender != SELF);
         uint256 snapshotId = vm.snapshot();
         bytes32 originalSalt = createXHarness.exposed_generateSalt();
 


### PR DESCRIPTION
### 🕓 Changelog

The fuzzing parameter `msgSender` in `testFuzz_ShouldBeAFunctionOfMultipleBlockPropertiesAndTheCaller` must _not_ equal `SELF` (i.e. `address(this)`, the test contract) for the following negative assertion to always hold:

```solidity
vm.startPrank(msgSender);
assertNotEq(originalSalt, createXHarness.exposed_generateSalt(), "1100");
vm.stopPrank();
```

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/d6cd3a4e-68a5-4ac6-b317-169bcc32d43c)