### PR TITLE
➖ Remove OP-Endurance Test Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -2238,7 +2238,6 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [LUKSO Testnet](https://explorer.execution.testnet.lukso.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Manta Pacific Testnet](https://pacific-explorer.testnet.manta.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Frame Testnet](https://explorer.testnet.frame.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
-- [OP-Endurance Testnet](https://explorer-l2-testnet.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Blast Testnet](https://sepolia.blastscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [DOS Chain Testnet](https://test.doscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Fraxtal Testnet](https://holesky.fraxscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -443,13 +443,6 @@
     ]
   },
   {
-    "name": "OP-Endurance Testnet",
-    "chainId": 6480001001,
-    "urls": [
-      "https://explorer-l2-testnet.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
-    ]
-  },
-  {
     "name": "Blast Testnet",
     "chainId": 168587773,
     "urls": [


### PR DESCRIPTION
### 🕓 Changelog

This PR removes the OP-Endurance test network, which has been completely shut down (I confirmed with the project team):

![image](https://github.com/pcaversaccio/createx/assets/25297591/6ccebb1b-feb4-4042-be33-872a90ad73af)

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/1a1fff30-1aab-45c4-9b7c-bda312f088da)