### PR TITLE
➕ Add Metis Main and Test Network Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2206,6 +2206,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [DOS Chain](https://doscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Endurance](https://explorer-endurance.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Kava](https://kavascan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Metis Andromeda](https://andromeda-explorer.metis.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 #### Ethereum Test Networks
 
@@ -2243,6 +2244,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Blast Sepolia Testnet](https://sepolia.blastscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [DOS Chain Testnet](https://test.doscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Fraxtal Holešky Testnet](https://holesky.fraxscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Metis Sepolia Testnet](https://sepolia-explorer.metisdevops.link/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -248,6 +248,13 @@
     ]
   },
   {
+    "name": "Metis Andromeda",
+    "chainId": 1088,
+    "urls": [
+      "https://andromeda-explorer.metis.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
+  },
+  {
     "name": "Sepolia",
     "chainId": 11155111,
     "urls": [
@@ -476,6 +483,13 @@
     "chainId": 2522,
     "urls": [
       "https://holesky.fraxscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
+  },
+  {
+    "name": "Metis Sepolia Testnet",
+    "chainId": 59902,
+    "urls": [
+      "https://sepolia-explorer.metisdevops.link/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -499,6 +499,19 @@ const config: HardhatUserConfig = {
       url: vars.get("KAVA_MAINNET_URL", "https://evm.kava-rpc.com"),
       accounts,
     },
+    metisTestnet: {
+      chainId: 59902,
+      url: vars.get("METIS_TESTNET_URL", "https://sepolia.metisdevops.link"),
+      accounts,
+    },
+    metisMain: {
+      chainId: 1088,
+      url: vars.get(
+        "METIS_MAINNET_URL",
+        "https://andromeda.metis.io/?owner=1088",
+      ),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -635,6 +648,9 @@ const config: HardhatUserConfig = {
       fraxtalTestnet: vars.get("FRAXTAL_API_KEY", ""),
       // For Kava mainnet
       kava: vars.get("KAVA_API_KEY", ""),
+      // For Metis testnet & mainnet
+      metis: vars.get("METIS_API_KEY", ""),
+      metisTestnet: vars.get("METIS_API_KEY", ""),
     },
     customChains: [
       {
@@ -1037,6 +1053,22 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://kavascan.com/api",
           browserURL: "https://kavascan.com",
+        },
+      },
+      {
+        network: "metis",
+        chainId: 1088,
+        urls: {
+          apiURL: "https://andromeda-explorer.metis.io/api",
+          browserURL: "https://andromeda-explorer.metis.io",
+        },
+      },
+      {
+        network: "metisTestnet",
+        chainId: 59902,
+        urls: {
+          apiURL: "https://sepolia-explorer.metisdevops.link/api",
+          browserURL: "https://sepolia-explorer.metisdevops.link",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -113,6 +113,8 @@
     "deploy:dosmain": "npx hardhat run --no-compile --network dosMain scripts/deploy.ts",
     "deploy:fraxtaltestnet": "npx hardhat run --no-compile --network fraxtalTestnet scripts/deploy.ts",
     "deploy:kavamain": "npx hardhat run --no-compile --network kavaMain scripts/deploy.ts",
+    "deploy:metistestnet": "npx hardhat run --no-compile --network metisTestnet scripts/deploy.ts",
+    "deploy:metismain": "npx hardhat run --no-compile --network metisMain scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "cd interface && pnpm prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",


### PR DESCRIPTION
### 🕓 Changelog

Add Metis test and main network (Andromeda) deployments:
- [Metis Andromeda](https://andromeda-explorer.metis.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed),
- [Metis Sepolia Testnet](https://sepolia-explorer.metisdevops.link/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://andromeda.metis.io/?owner=1088)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f

~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://sepolia.metisdevops.link)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```
 
#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/aee6b1af-2ae8-42fa-8034-025c2f7ebc4b)