### PR TITLE
➕ Add Mode Sepolia Testnet Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2245,6 +2245,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [DOS Chain Testnet](https://test.doscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Fraxtal Holešky Testnet](https://holesky.fraxscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Metis Sepolia Testnet](https://sepolia-explorer.metisdevops.link/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Mode Sepolia Testnet](https://sepolia.explorer.mode.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -491,5 +491,13 @@
     "urls": [
       "https://sepolia-explorer.metisdevops.link/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
+  },
+  {
+    "name": "Mode Sepolia Testnet",
+    "chainId": 919,
+    "urls": [
+      "https://sepolia.explorer.mode.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "https://repo.sourcify.dev/contracts/partial_match/919/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed/"
+    ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -512,6 +512,11 @@ const config: HardhatUserConfig = {
       ),
       accounts,
     },
+    modeTestnet: {
+      chainId: 919,
+      url: vars.get("MODE_TESTNET_URL", "https://sepolia.mode.network"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -651,6 +656,8 @@ const config: HardhatUserConfig = {
       // For Metis testnet & mainnet
       metis: vars.get("METIS_API_KEY", ""),
       metisTestnet: vars.get("METIS_API_KEY", ""),
+      // For Mode testnet
+      modeTestnet: vars.get("MODE_API_KEY", ""),
     },
     customChains: [
       {
@@ -1069,6 +1076,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://sepolia-explorer.metisdevops.link/api",
           browserURL: "https://sepolia-explorer.metisdevops.link",
+        },
+      },
+      {
+        network: "modeTestnet",
+        chainId: 919,
+        urls: {
+          apiURL: "https://sepolia.explorer.mode.network/api",
+          browserURL: "https://sepolia.explorer.mode.network",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "deploy:kavamain": "npx hardhat run --no-compile --network kavaMain scripts/deploy.ts",
     "deploy:metistestnet": "npx hardhat run --no-compile --network metisTestnet scripts/deploy.ts",
     "deploy:metismain": "npx hardhat run --no-compile --network metisMain scripts/deploy.ts",
+    "deploy:modetestnet": "npx hardhat run --no-compile --network modeTestnet scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "cd interface && pnpm prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",


### PR DESCRIPTION
### 🕓 Changelog

Add Mode Sepolia test network deployment (closes #104):
- [Mode Sepolia Testnet](https://sepolia.explorer.mode.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://sepolia.mode.network)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```
 
#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/6874096a-e302-42de-96a9-3de95259c5d3)