### PR TITLE
👷 Update `lcov-reporter-action` GitHub Action

### DIFF
--- a/.github/workflows/test-createx.yml
+++ b/.github/workflows/test-createx.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Post coverage report
         # See https://github.com/orgs/community/discussions/26829#discussioncomment-3253575.
         if: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') }}
-        uses: romeovs/lcov-reporter-action@v0.3.1
+        uses: sunsergdev/lcov-reporter-action@v0.3.1-fork
         with:
           delete-old-comments: true
           lcov-file: ./lcov.info

--- a/.github/workflows/test-createx.yml
+++ b/.github/workflows/test-createx.yml
@@ -160,7 +160,7 @@ jobs:
         if: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') }}
         uses: sunsergdev/lcov-reporter-action@v0.3.1-fork
         with:
-          title: "`CreateX` Coverage Report"
+          title: "`CreateX` Test Coverage Report"
           delete-old-comments: true
           lcov-file: ./lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-createx.yml
+++ b/.github/workflows/test-createx.yml
@@ -160,6 +160,7 @@ jobs:
         if: ${{ (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') }}
         uses: sunsergdev/lcov-reporter-action@v0.3.1-fork
         with:
+          title: "`CreateX` Coverage Report"
           delete-old-comments: true
           lcov-file: ./lcov.info
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 🕓 Changelog

Since the original [`romeovs/lcov-reporter-action`](https://github.com/romeovs/lcov-reporter-action) GitHub action seems unmaintained and is still running on the deprecated `Node.js` version `16`, we upgrade to the fork [`sunsergdev/lcov-reporter-action`](https://github.com/sunsergdev/lcov-reporter-action/tree/v0.3.1-fork) that runs on `Node.js` version `20`. Also, see issue: https://github.com/romeovs/lcov-reporter-action/issues/55.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/75001f79-2f89-4f4c-a1d4-6b955dcacda4)