### PR TITLE
➕ Add Mode Main Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2207,6 +2207,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Endurance](https://explorer-endurance.fusionist.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Kava](https://kavascan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Metis Andromeda](https://andromeda-explorer.metis.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Mode](https://explorer.mode.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 #### Ethereum Test Networks
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -255,6 +255,14 @@
     ]
   },
   {
+    "name": "Mode",
+    "chainId": 34443,
+    "urls": [
+      "https://explorer.mode.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "https://repo.sourcify.dev/contracts/partial_match/34443/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed/"
+    ]
+  },
+  {
     "name": "Sepolia",
     "chainId": 11155111,
     "urls": [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -517,6 +517,11 @@ const config: HardhatUserConfig = {
       url: vars.get("MODE_TESTNET_URL", "https://sepolia.mode.network"),
       accounts,
     },
+    modeMain: {
+      chainId: 34443,
+      url: vars.get("MODE_MAINNET_URL", "https://mainnet.mode.network"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -656,7 +661,8 @@ const config: HardhatUserConfig = {
       // For Metis testnet & mainnet
       metis: vars.get("METIS_API_KEY", ""),
       metisTestnet: vars.get("METIS_API_KEY", ""),
-      // For Mode testnet
+      // For Mode testnet & mainnet
+      mode: vars.get("MODE_API_KEY", ""),
       modeTestnet: vars.get("MODE_API_KEY", ""),
     },
     customChains: [
@@ -1076,6 +1082,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://sepolia-explorer.metisdevops.link/api",
           browserURL: "https://sepolia-explorer.metisdevops.link",
+        },
+      },
+      {
+        network: "mode",
+        chainId: 34443,
+        urls: {
+          apiURL: "https://explorer.mode.network/api",
+          browserURL: "https://explorer.mode.network",
         },
       },
       {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "deploy:metistestnet": "npx hardhat run --no-compile --network metisTestnet scripts/deploy.ts",
     "deploy:metismain": "npx hardhat run --no-compile --network metisMain scripts/deploy.ts",
     "deploy:modetestnet": "npx hardhat run --no-compile --network modeTestnet scripts/deploy.ts",
+    "deploy:modemain": "npx hardhat run --no-compile --network modeMain scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "cd interface && pnpm prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",


### PR DESCRIPTION
### 🕓 Changelog

Add Mode main network deployment (closes #107):
- [Mode](https://explorer.mode.network/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://mainnet.mode.network)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```
 
#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/createx/assets/25297591/15f80416-8509-4d8d-9693-8e06411c5c93)