### PR TITLE
➕ Add Chiliz Main Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2213,6 +2213,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Core](https://scan.coredao.org/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Telos](https://www.teloscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Rootstock](https://rootstock.blockscout.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Chiliz](https://chiliscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Taraxa](https://mainnet.explorer.taraxa.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 #### Ethereum Test Networks

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -311,6 +311,13 @@
     ]
   },
   {
+    "name": "Chiliz",
+    "chainId": 88888,
+    "urls": [
+      "https://chiliscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
+  },
+  {
     "name": "Taraxa",
     "chainId": 841,
     "urls": [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -590,6 +590,11 @@ const config: HardhatUserConfig = {
       url: vars.get("CHILIZ_TESTNET_URL", "https://spicy-rpc.chiliz.com"),
       accounts,
     },
+    chilizMain: {
+      chainId: 88888,
+      url: vars.get("CHILIZ_MAINNET_URL", "https://rpc.ankr.com/chiliz"),
+      accounts,
+    },
     taraxaTestnet: {
       chainId: 842,
       url: vars.get("TARAXA_TESTNET_URL", "https://rpc.testnet.taraxa.io"),
@@ -758,7 +763,8 @@ const config: HardhatUserConfig = {
       // For Rootstock testnet & mainnet
       rootstock: vars.get("ROOTSTOCK_API_KEY", ""),
       rootstockTestnet: vars.get("ROOTSTOCK_API_KEY", ""),
-      // For Chiliz testnet
+      // For Chiliz testnet & mainnet
+      chiliz: vars.get("CHILIZ_API_KEY", ""),
       chilizTestnet: vars.get("CHILIZ_API_KEY", ""),
     },
     customChains: [
@@ -1284,6 +1290,15 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://rootstock-testnet.blockscout.com/api",
           browserURL: "https://rootstock-testnet.blockscout.com",
+        },
+      },
+      {
+        network: "chiliz",
+        chainId: 88888,
+        urls: {
+          apiURL:
+            "https://api.routescan.io/v2/network/mainnet/evm/88888/etherscan/api",
+          browserURL: "https://chiliscan.com",
         },
       },
       {

--- a/interface/package.json
+++ b/interface/package.json
@@ -40,7 +40,7 @@
     "sharp": "^0.33.4"
   },
   "devDependencies": {
-    "@eslint/js": "^9.6.0",
+    "@eslint/js": "^9.7.0",
     "@next/eslint-plugin-next": "^14.2.5",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20.14.10",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "deploy:rootstocktestnet": "npx hardhat run --no-compile --network rootstockTestnet scripts/deploy.ts",
     "deploy:rootstockmain": "npx hardhat run --no-compile --network rootstockMain scripts/deploy.ts",
     "deploy:chiliztestnet": "npx hardhat run --no-compile --network chilizTestnet scripts/deploy.ts",
+    "deploy:chilizmain": "npx hardhat run --no-compile --network chilizMain scripts/deploy.ts",
     "deploy:taraxatestnet": "npx hardhat run --no-compile --network taraxaTestnet scripts/deploy.ts",
     "deploy:taraxamain": "npx hardhat run --no-compile --network taraxaMain scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
@@ -147,7 +148,7 @@
     "start:interface": "cd interface && pnpm start"
   },
   "devDependencies": {
-    "@eslint/js": "^9.6.0",
+    "@eslint/js": "^9.7.0",
     "@nomicfoundation/hardhat-ethers": "^3.0.6",
     "@nomicfoundation/hardhat-verify": "^2.0.8",
     "@typechain/ethers-v6": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
   .:
     devDependencies:
       "@eslint/js":
-        specifier: ^9.6.0
-        version: 9.6.0
+        specifier: ^9.7.0
+        version: 9.7.0
       "@nomicfoundation/hardhat-ethers":
         specifier: ^3.0.6
         version: 3.0.6(ethers@6.13.1)(hardhat@2.22.6(ts-node@10.9.2(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3))
@@ -93,8 +93,8 @@ importers:
         version: 0.33.4
     devDependencies:
       "@eslint/js":
-        specifier: ^9.6.0
-        version: 9.6.0
+        specifier: ^9.7.0
+        version: 9.7.0
       "@next/eslint-plugin-next":
         specifier: ^14.2.5
         version: 14.2.5
@@ -323,10 +323,10 @@ packages:
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
-  "@eslint/js@9.6.0":
+  "@eslint/js@9.7.0":
     resolution:
       {
-        integrity: sha512-D9B0/3vNg44ZeWbYMpBoXqNP4j6eQD5vNwIlGAuFRRzK/WtT/jvDQW3Bi9kkf3PMDMlM7Yi+73VLUsn5bJcl8A==,
+        integrity: sha512-ChuWDQenef8OSFnvuxv0TCVxEwmu3+hPNKvM9B34qpM0rDRbjL8t5QkQeHHeAfsKQjuH9wS82WeCi1J/owatng==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -1349,10 +1349,10 @@ packages:
         integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==,
       }
 
-  "@swc/helpers@0.5.11":
+  "@swc/helpers@0.5.12":
     resolution:
       {
-        integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==,
+        integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==,
       }
 
   "@swc/helpers@0.5.5":
@@ -1722,10 +1722,10 @@ packages:
         integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
       }
 
-  ajv@8.16.0:
+  ajv@8.17.1:
     resolution:
       {
-        integrity: sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==,
+        integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==,
       }
 
   ansi-align@3.0.1:
@@ -2970,6 +2970,12 @@ packages:
     resolution:
       {
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
+
+  fast-uri@3.0.1:
+    resolution:
+      {
+        integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==,
       }
 
   fastq@1.17.1:
@@ -6020,7 +6026,7 @@ snapshots:
 
   "@eslint/js@8.57.0": {}
 
-  "@eslint/js@9.6.0": {}
+  "@eslint/js@9.7.0": {}
 
   "@ethersproject/abi@5.7.0":
     dependencies:
@@ -6497,7 +6503,7 @@ snapshots:
       "@react-aria/interactions": 3.21.3(react@18.3.1)
       "@react-aria/utils": 3.24.1(react@18.3.1)
       "@react-types/shared": 3.23.1(react@18.3.1)
-      "@swc/helpers": 0.5.11
+      "@swc/helpers": 0.5.12
       clsx: 2.1.1
       react: 18.3.1
 
@@ -6506,12 +6512,12 @@ snapshots:
       "@react-aria/ssr": 3.9.4(react@18.3.1)
       "@react-aria/utils": 3.24.1(react@18.3.1)
       "@react-types/shared": 3.23.1(react@18.3.1)
-      "@swc/helpers": 0.5.11
+      "@swc/helpers": 0.5.12
       react: 18.3.1
 
   "@react-aria/ssr@3.9.4(react@18.3.1)":
     dependencies:
-      "@swc/helpers": 0.5.11
+      "@swc/helpers": 0.5.12
       react: 18.3.1
 
   "@react-aria/utils@3.24.1(react@18.3.1)":
@@ -6519,13 +6525,13 @@ snapshots:
       "@react-aria/ssr": 3.9.4(react@18.3.1)
       "@react-stately/utils": 3.10.1(react@18.3.1)
       "@react-types/shared": 3.23.1(react@18.3.1)
-      "@swc/helpers": 0.5.11
+      "@swc/helpers": 0.5.12
       clsx: 2.1.1
       react: 18.3.1
 
   "@react-stately/utils@3.10.1(react@18.3.1)":
     dependencies:
-      "@swc/helpers": 0.5.11
+      "@swc/helpers": 0.5.12
       react: 18.3.1
 
   "@react-types/shared@3.23.1(react@18.3.1)":
@@ -6626,7 +6632,7 @@ snapshots:
 
   "@swc/counter@0.1.3": {}
 
-  "@swc/helpers@0.5.11":
+  "@swc/helpers@0.5.12":
     dependencies:
       tslib: 2.6.3
 
@@ -6883,12 +6889,12 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.16.0:
+  ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
+      fast-uri: 3.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-      uri-js: 4.4.1
 
   ansi-align@3.0.1:
     dependencies:
@@ -7856,6 +7862,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.0.1: {}
 
   fastq@1.17.1:
     dependencies:
@@ -9323,7 +9331,7 @@ snapshots:
 
   table@6.8.2:
     dependencies:
-      ajv: 8.16.0
+      ajv: 8.17.1
       lodash.truncate: 4.4.2
       slice-ansi: 4.0.0
       string-width: 4.2.3


### PR DESCRIPTION
### 🕓 Changelog

Add Chiliz main network deployment (closes #125):
- [Chiliz](https://chiliscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://rpc.ankr.com/chiliz)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

![image](https://github.com/user-attachments/assets/5c8cd622-c398-4173-be61-ba78bafa1b10)