### PR TITLE
➕ Add Oasis Sapphire Test and Main Network Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2220,6 +2220,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Taiko](https://taikoscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [ZetaChain](https://explorer.zetachain.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [5ireChain](https://5irescan.io/contract/evm/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Oasis Sapphire](https://explorer.oasis.io/mainnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 #### Ethereum Test Networks
 
@@ -2269,6 +2270,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Taiko Holešky Testnet](https://hekla.taikoscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [ZetaChain Testnet (Athens-3)](https://athens.explorer.zetachain.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [5ireChain Testnet](https://testnet.5irescan.io/contract/evm/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Oasis Sapphire Testnet](https://explorer.oasis.io/testnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -674,5 +674,19 @@
     "urls": [
       "https://testnet.5irescan.io/contract/evm/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
+  },
+  {
+    "name": "Oasis Sapphire",
+    "chainId": 23294,
+    "urls": [
+      "https://explorer.oasis.io/mainnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
+  },
+  {
+    "name": "Oasis Sapphire Testnet",
+    "chainId": 23295,
+    "urls": [
+      "https://explorer.oasis.io/testnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
   }
 ]

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -354,6 +354,14 @@
     ]
   },
   {
+    "name": "Oasis Sapphire",
+    "chainId": 23294,
+    "urls": [
+      "https://explorer.oasis.io/mainnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "https://repo.sourcify.dev/contracts/partial_match/23294/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed/"
+    ]
+  },
+  {
     "name": "Sepolia",
     "chainId": 11155111,
     "urls": [
@@ -676,17 +684,11 @@
     ]
   },
   {
-    "name": "Oasis Sapphire",
-    "chainId": 23294,
-    "urls": [
-      "https://explorer.oasis.io/mainnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
-    ]
-  },
-  {
     "name": "Oasis Sapphire Testnet",
     "chainId": 23295,
     "urls": [
-      "https://explorer.oasis.io/testnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+      "https://explorer.oasis.io/testnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "https://repo.sourcify.dev/contracts/partial_match/23295/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed/"
     ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -651,6 +651,14 @@ const config: HardhatUserConfig = {
       url: vars.get("5IRE_CHAIN_MAINNET_URL", "https://rpc.5ire.network"),
       accounts,
     },
+    sapphireMain: {
+      url: 'https://sapphire.oasis.io',
+      chainId: 0x5afe,
+    },
+    sapphireTestnet: {
+      url: 'https://testnet.sapphire.oasis.io',
+      chainId: 0x5aff,
+    }
   },
   contractSizer: {
     alphaSort: true,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -651,14 +651,19 @@ const config: HardhatUserConfig = {
       url: vars.get("5IRE_CHAIN_MAINNET_URL", "https://rpc.5ire.network"),
       accounts,
     },
-    sapphireMain: {
-      url: 'https://sapphire.oasis.io',
-      chainId: 0x5afe,
-    },
     sapphireTestnet: {
-      url: 'https://testnet.sapphire.oasis.io',
-      chainId: 0x5aff,
-    }
+      chainId: 23295,
+      url: vars.get(
+        "SAPPHIRE_TESTNET_URL",
+        "https://testnet.sapphire.oasis.io",
+      ),
+      accounts,
+    },
+    sapphireMain: {
+      chainId: 23294,
+      url: vars.get("SAPPHIRE_MAINNET_URL", "https://sapphire.oasis.io"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -832,6 +837,9 @@ const config: HardhatUserConfig = {
       // For 5ireChain testnet & mainnet
       "5ireChain": vars.get("5IRE_CHAIN_API_KEY", ""),
       "5ireChainTestnet": vars.get("5IRE_CHAIN_API_KEY", ""),
+      // For Oasis Sapphire testnet & mainnet
+      sapphire: vars.get("SAPPHIRE_API_KEY", ""),
+      sapphireTestnet: vars.get("SAPPHIRE_API_KEY", ""),
     },
     customChains: [
       {
@@ -1454,6 +1462,22 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://testnet.5irescan.io/api",
           browserURL: "https://testnet.5irescan.io",
+        },
+      },
+      {
+        network: "sapphire",
+        chainId: 23294,
+        urls: {
+          apiURL: "https://explorer.oasis.io/mainnet/sapphire/api",
+          browserURL: "https://explorer.oasis.io/mainnet/sapphire",
+        },
+      },
+      {
+        network: "sapphireTestnet",
+        chainId: 23295,
+        urls: {
+          apiURL: "https://explorer.oasis.io/testnet/sapphire/api",
+          browserURL: "https://explorer.oasis.io/testnet/sapphire",
         },
       },
     ],

--- a/interface/package.json
+++ b/interface/package.json
@@ -55,7 +55,7 @@
     "postcss": "^8.4.47",
     "prettier": "^3.3.3",
     "prettier-plugin-tailwindcss": "^0.6.6",
-    "tailwindcss": "^3.4.12",
+    "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "typescript-eslint": "^7.18.0"
   }

--- a/interface/src/pages/index.tsx
+++ b/interface/src/pages/index.tsx
@@ -19,7 +19,7 @@ const Home = () => {
       id: 1,
       href: "/deployments",
       title: "Deployments",
-      subtitle: "Deployed on 80+ chains",
+      subtitle: "Deployed on 90+ chains",
     },
     { id: 2, href: "/abi", title: "ABI", subtitle: "In any format" },
     {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,8 @@
     "deploy:zetachainmain": "npx hardhat run --no-compile --network zetaChainMain scripts/deploy.ts",
     "deploy:5irechaintestnet": "npx hardhat run --no-compile --network 5ireChainTestnet scripts/deploy.ts",
     "deploy:5irechainmain": "npx hardhat run --no-compile --network 5ireChainMain scripts/deploy.ts",
+    "deploy:sapphiretestnet": "npx hardhat run --no-compile --network sapphireTestnet scripts/deploy.ts",
+    "deploy:sapphiremain": "npx hardhat run --no-compile --network sapphireMain scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "cd interface && pnpm prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^0.6.6
         version: 0.6.6(@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3))(prettier@3.3.3)
       tailwindcss:
-        specifier: ^3.4.12
-        version: 3.4.12(ts-node@10.9.2(@types/node@22.5.5)(typescript@5.6.2))
+        specifier: ^3.4.13
+        version: 3.4.13(ts-node@10.9.2(@types/node@22.5.5)(typescript@5.6.2))
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1313,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001662:
-    resolution: {integrity: sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==}
+  caniuse-lite@1.0.30001663:
+    resolution: {integrity: sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==}
 
   cbor@8.1.0:
     resolution: {integrity: sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==}
@@ -1335,8 +1335,8 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chokidar@4.0.0:
-    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
+  chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
     engines: {node: '>= 14.16.0'}
 
   ci-info@2.0.0:
@@ -3225,8 +3225,8 @@ packages:
     resolution: {integrity: sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==}
     engines: {node: '>=10.0.0'}
 
-  tailwindcss@3.4.12:
-    resolution: {integrity: sha512-Htf/gHj2+soPb9UayUNci/Ja3d8pTmu9ONTfh4QY8r3MATTZOzmv6UYWF7ZwikEIC8okpfqmGqrmDehua8mF8w==}
+  tailwindcss@3.4.13:
+    resolution: {integrity: sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -4797,7 +4797,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.4.47):
     dependencies:
       browserslist: 4.23.3
-      caniuse-lite: 1.0.30001662
+      caniuse-lite: 1.0.30001663
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.0
@@ -4875,7 +4875,7 @@ snapshots:
 
   browserslist@4.23.3:
     dependencies:
-      caniuse-lite: 1.0.30001662
+      caniuse-lite: 1.0.30001663
       electron-to-chromium: 1.5.27
       node-releases: 2.0.18
       update-browserslist-db: 1.1.0(browserslist@4.23.3)
@@ -4926,7 +4926,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001662: {}
+  caniuse-lite@1.0.30001663: {}
 
   cbor@8.1.0:
     dependencies:
@@ -4957,7 +4957,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@4.0.0:
+  chokidar@4.0.1:
     dependencies:
       readdirp: 4.0.1
 
@@ -5974,7 +5974,7 @@ snapshots:
       ansi-escapes: 4.3.2
       boxen: 5.1.2
       chalk: 2.4.2
-      chokidar: 4.0.0
+      chokidar: 4.0.1
       ci-info: 2.0.0
       debug: 4.3.7(supports-color@8.1.1)
       enquirer: 2.4.1
@@ -6480,7 +6480,7 @@ snapshots:
       '@next/env': 14.2.13
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
-      caniuse-lite: 1.0.30001662
+      caniuse-lite: 1.0.30001663
       graceful-fs: 4.2.11
       postcss: 8.4.31
       react: 18.3.1
@@ -7175,7 +7175,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.4.12(ts-node@10.9.2(@types/node@22.5.5)(typescript@5.6.2)):
+  tailwindcss@3.4.13(ts-node@10.9.2(@types/node@22.5.5)(typescript@5.6.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2


### PR DESCRIPTION
### 🕓 Changelog

Add Oasis Sapphire test and main network deployments:
- [Oasis Sapphire Testnet](https://explorer.oasis.io/testnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed),
- [Oasis Sapphire](https://explorer.oasis.io/mainnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://testnet.sapphire.oasis.io)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://sapphire.oasis.io)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

![IMG_0359](https://github.com/user-attachments/assets/473d434c-5bff-444a-a6ed-363caffaf96a)