### PR TITLE
➕ Add Story Odyssey Test Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2287,6 +2287,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Lisk Sepolia Testnet](https://sepolia-blockscout.lisk.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Metal L2 Sepolia Testnet](https://testnet.explorer.metall2.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Superseed Sepolia Testnet](https://sepolia-explorer.superseed.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Story Testnet (Odyssey)](https://odyssey.storyscan.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -782,5 +782,12 @@
     "urls": [
       "https://sepolia-explorer.superseed.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
+  },
+  {
+    "name": "Story Testnet (Odyssey)",
+    "chainId": 1516,
+    "urls": [
+      "https://odyssey.storyscan.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -738,6 +738,11 @@ const config: HardhatUserConfig = {
       url: vars.get("SUPERSEED_TESTNET_URL", "https://sepolia.superseed.xyz"),
       accounts,
     },
+    storyTestnet: {
+      chainId: 1516,
+      url: vars.get("STORY_TESTNET_URL", "https://odyssey.storyrpc.io"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -935,6 +940,8 @@ const config: HardhatUserConfig = {
       metalL2Testnet: vars.get("METALL2_API_KEY", ""),
       // For Superseed testnet
       superseedTestnet: vars.get("SUPERSEED_API_KEY", ""),
+      // For Story testnet
+      storyTestnet: vars.get("STORY_API_KEY", ""),
     },
     customChains: [
       {
@@ -1677,6 +1684,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://sepolia-explorer.superseed.xyz/api",
           browserURL: "https://sepolia-explorer.superseed.xyz",
+        },
+      },
+      {
+        network: "storyTestnet",
+        chainId: 1516,
+        urls: {
+          apiURL: "https://odyssey.storyscan.xyz/api",
+          browserURL: "https://odyssey.storyscan.xyz",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "deploy:metall2testnet": "npx hardhat run --no-compile --network metalL2Testnet scripts/deploy.ts",
     "deploy:metall2main": "npx hardhat run --no-compile --network metalL2Main scripts/deploy.ts",
     "deploy:superseedtestnet": "npx hardhat run --no-compile --network superseedTestnet scripts/deploy.ts",
+    "deploy:storytestnet": "npx hardhat run --no-compile --network storyTestnet scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "cd interface && pnpm prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",


### PR DESCRIPTION
### 🕓 Changelog

Add Story test network (Odyssey) deployment (closes #156):
- [Story Testnet (Odyssey)](https://odyssey.storyscan.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://odyssey.storyrpc.io)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

![image](https://github.com/user-attachments/assets/c568db67-da26-4bad-ac5f-944e47e808db)