### PR TITLE
➕ Add Plume Main Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2225,6 +2225,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [5ireChain](https://5irescan.io/contract/evm/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Oasis Sapphire](https://explorer.oasis.io/mainnet/sapphire/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [World Chain](https://worldchain-mainnet.explorer.alchemy.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Plume](https://explorer.plumenetwork.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [XDC Network](https://xdcscan.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [SX Network](https://explorerl2.sx.technology/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Lisk](https://blockscout.lisk.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -369,6 +369,13 @@
     ]
   },
   {
+    "name": "Plume",
+    "chainId": 98865,
+    "urls": [
+      "https://explorer.plumenetwork.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
+  },
+  {
     "name": "XDC Network",
     "chainId": 50,
     "urls": [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -685,6 +685,11 @@ const config: HardhatUserConfig = {
       url: vars.get("PLUME_TESTNET_URL", "https://test-rpc.plumenetwork.xyz"),
       accounts,
     },
+    plumeMain: {
+      chainId: 98865,
+      url: vars.get("PLUME_MAINNET_URL", "https://rpc.plumenetwork.xyz"),
+      accounts,
+    },
     unichainTestnet: {
       chainId: 1301,
       url: vars.get("UNICHAIN_TESTNET_URL", "https://sepolia.unichain.org"),
@@ -937,7 +942,8 @@ const config: HardhatUserConfig = {
       // For World Chain testnet & mainnet
       worldChain: vars.get("WORLD_CHAIN_API_KEY", ""),
       worldChainTestnet: vars.get("WORLD_CHAIN_API_KEY", ""),
-      // For Plume testnet
+      // For Plume testnet & mainnet
+      plume: vars.get("PLUME_API_KEY", ""),
       plumeTestnet: vars.get("PLUME_API_KEY", ""),
       // For Unichain testnet
       unichainTestnet: vars.get("UNICHAIN_API_KEY", ""),
@@ -1615,6 +1621,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://worldchain-sepolia.explorer.alchemy.com/api",
           browserURL: "https://worldchain-sepolia.explorer.alchemy.com",
+        },
+      },
+      {
+        network: "plume",
+        chainId: 98865,
+        urls: {
+          apiURL: "https://explorer.plumenetwork.xyz/api",
+          browserURL: "https://explorer.plumenetwork.xyz",
         },
       },
       {

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "deploy:worldchaintestnet": "npx hardhat run --no-compile --network worldChainTestnet scripts/deploy.ts",
     "deploy:worldchainmain": "npx hardhat run --no-compile --network worldChainMain scripts/deploy.ts",
     "deploy:plumetestnet": "npx hardhat run --no-compile --network plumeTestnet scripts/deploy.ts",
+    "deploy:plumemain": "npx hardhat run --no-compile --network plumeMain scripts/deploy.ts",
     "deploy:unichaintestnet": "npx hardhat run --no-compile --network unichainTestnet scripts/deploy.ts",
     "deploy:xdctestnet": "npx hardhat run --no-compile --network xdcTestnet scripts/deploy.ts",
     "deploy:xdcmain": "npx hardhat run --no-compile --network xdcMain scripts/deploy.ts",


### PR DESCRIPTION
### 🕓 Changelog

Add Plume main network deployment (closes #161):
- [Plume](https://explorer.plumenetwork.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://rpc.plumenetwork.xyz)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

![image](https://github.com/user-attachments/assets/6c2cea9d-a42f-47a8-bb53-2ad81adad69e)