### PR TITLE
➕ Add Katana Main Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2257,6 +2257,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [ApeChain](https://apescan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Botanix](https://botanixscan.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [TAC](https://explorer.tac.build/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Katana](https://explorer.katanarpc.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 #### Ethereum Test Networks
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -604,6 +604,13 @@
     ]
   },
   {
+    "name": "Katana",
+    "chainId": 747474,
+    "urls": [
+      "https://explorer.katanarpc.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
+  },
+  {
     "name": "Sepolia",
     "chainId": 11155111,
     "urls": [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1092,6 +1092,11 @@ const config: HardhatUserConfig = {
       ),
       accounts,
     },
+    katanaMain: {
+      chainId: 747474,
+      url: vars.get("KATANA_MAINNET_URL", "https://rpc.katana.network"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -1366,6 +1371,8 @@ const config: HardhatUserConfig = {
       // For Neon EVM testnet & mainnet
       neon: vars.get("NEON_API_KEY", ""),
       neonTestnet: vars.get("NEON_API_KEY", ""),
+      // For Katana mainnet
+      katana: vars.get("KATANA_API_KEY", ""),
     },
     customChains: [
       {
@@ -2546,6 +2553,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://devnet-api.neonscan.org/hardhat/verify",
           browserURL: "https://devnet.neonscan.org",
+        },
+      },
+      {
+        network: "katana",
+        chainId: 747474,
+        urls: {
+          apiURL: "https://explorer.katanarpc.com/api",
+          browserURL: "https://explorer.katanarpc.com",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "deploy:tacmain": "npx hardhat run --no-compile --network tacMain scripts/deploy.ts",
     "deploy:neontestnet": "npx hardhat run --no-compile --network neonTestnet scripts/deploy.ts",
     "deploy:neonmain": "npx hardhat run --no-compile --network neonMain scripts/deploy.ts",
+    "deploy:katanamain": "npx hardhat run --no-compile --network katanaMain scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "pnpm -C interface prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",


### PR DESCRIPTION
### 🕓 Changelog

Add Katana main network deployment (resolves #225):
- [Katana](https://explorer.katanarpc.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://rpc.katana.network)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/9afc1051-4eb1-4899-905b-ccf354b224b0 width="1050"/>