### PR TITLE
♻️ Relax Solidity Version Requirement to `>=0.8.23 <0.9.0`

### DIFF
--- a/src/CreateX.sol
+++ b/src/CreateX.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 /**
  * @title CreateX Factory Smart Contract


### PR DESCRIPTION
### 🕓 Changelog

This PR relaxes the Solidity version constraint to `>= 0.8.23 < 0.9.0`.