### PR TITLE
➕ Add Arc Test Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2363,6 +2363,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [MemeCore Testnet (Insectarium)](https://insectarium.blockscout.memecore.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [LightLink Testnet (Pegasus)](https://pegasus.lightlink.io/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [XRPL EVM Testnet](https://explorer.testnet.xrplevm.org/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Arc Testnet](https://testnet.arcscan.app/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -1328,5 +1328,13 @@
     "urls": [
       "https://explorer.testnet.xrplevm.org/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
+  },
+  {
+    "name": "Arc Testnet",
+    "chainId": 5042002,
+    "urls": [
+      "https://testnet.arcscan.app/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "https://repo.sourcify.dev/5042002/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1213,6 +1213,11 @@ const config: HardhatUserConfig = {
       url: vars.get("XRPLEVM_MAINNET_URL", "https://rpc.xrplevm.org"),
       accounts,
     },
+    arcTestnet: {
+      chainId: 5042002,
+      url: vars.get("ARC_TESTNET_URL", "https://rpc.testnet.arc.network"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -1515,6 +1520,8 @@ const config: HardhatUserConfig = {
       // For XRPL EVM testnet & mainnet
       xrplEVM: vars.get("XRPLEVM_API_KEY", ""),
       xrplEVMTestnet: vars.get("XRPLEVM_API_KEY", ""),
+      // For Arc testnet
+      arcTestnet: vars.get("ARC_API_KEY", ""),
     },
     customChains: [
       {
@@ -2849,6 +2856,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://explorer.testnet.xrplevm.org/api",
           browserURL: "https://explorer.testnet.xrplevm.org",
+        },
+      },
+      {
+        network: "arcTestnet",
+        chainId: 5042002,
+        urls: {
+          apiURL: "https://testnet.arcscan.app/api",
+          browserURL: "https://testnet.arcscan.app",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -237,6 +237,7 @@
     "deploy:lightlinkmain": "npx hardhat run --no-compile --network lightlinkMain scripts/deploy.ts",
     "deploy:xrplevmtestnet": "npx hardhat run --no-compile --network xrplEVMTestnet scripts/deploy.ts",
     "deploy:xrplevmmain": "npx hardhat run --no-compile --network xrplEVMMain scripts/deploy.ts",
+    "deploy:arctestnet": "npx hardhat run --no-compile --network arcTestnet scripts/deploy.ts",
     "prettier:check": "npx prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "pnpm -C interface prettier:check",
     "prettier:fix": "npx prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5404,7 +5404,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -5441,7 +5441,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -5456,7 +5456,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
### 🕓 Changelog

Add Arc test network deployment (resolves #266):
- [Arc Testnet](https://testnet.arcscan.app/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://rpc.testnet.arc.network)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/6d573222-69a8-47af-b880-f180f59e7d9a width="1050"/>