### PR TITLE
➕ Add PulseChain Test and Main Network Deployments

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1263,6 +1263,16 @@ const config: HardhatUserConfig = {
       url: vars.get("LENS_MAINNET_URL", "https://rpc.lens.xyz"),
       accounts,
     },
+    pulseTestnet: {
+      chainId: 943,
+      url: vars.get("PULSE_TESTNET_URL", "https://rpc.v4.testnet.pulsechain.com"),
+      accounts,
+    },
+    pulseMain: {
+      chainId: 369,
+      url: vars.get("PULSE_MAINNET_URL", "https://rpc.pulsechain.com"),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -1582,6 +1592,10 @@ const config: HardhatUserConfig = {
       // For Lens testnet & mainnet
       lens: vars.get("LENS_API_KEY", ""),
       lensTestnet: vars.get("LENS_API_KEY", ""),
+      // For PulseChain testnet & mainnet (Blockscout — no key required,
+      // empty string is fine)
+      pulseMain: vars.get("PULSE_API_KEY", ""),
+      pulseTestnet: vars.get("PULSE_API_KEY", ""),
     },
     customChains: [
       {
@@ -3005,6 +3019,24 @@ const config: HardhatUserConfig = {
           apiURL:
             "https://block-explorer-verify.testnet.lens.xyz/contract_verification",
           browserURL: "https://explorer.testnet.lens.xyz",
+        },
+      },
+      {
+        network: "pulseMain",
+        chainId: 369,
+        urls: {
+          // PulseChain runs Blockscout. No Etherscan-style API key required —
+          // the `apiKey: ""` entry above keeps hardhat-verify happy.
+          apiURL: "https://api.scan.pulsechain.com/api",
+          browserURL: "https://scan.pulsechain.com",
+        },
+      },
+      {
+        network: "pulseTestnet",
+        chainId: 943,
+        urls: {
+          apiURL: "https://api.scan.v4.testnet.pulsechain.com/api",
+          browserURL: "https://scan.v4.testnet.pulsechain.com",
         },
       },
     ],


### PR DESCRIPTION
### 🕓 Changelog

Companion PR to #287 — wires PulseChain mainnet (chainId `369`) and PulseChain testnet v4 (chainId `943`) into `hardhat.config.ts` so that once a fresh pre-signed deployment tx lands, `pnpm hardhat run … --network pulseMain` works out of the box.

## Changes

- `networks.pulseMain` — chainId 369, RPC from `PULSE_MAINNET_URL` (default `https://rpc.pulsechain.com`)
- `networks.pulseTestnet` — chainId 943, RPC from `PULSE_TESTNET_URL` (default `https://rpc.v4.testnet.pulsechain.com`)
- `etherscan.apiKey.pulseMain` / `pulseTestnet` — read from `PULSE_API_KEY` (empty string is fine; see below)
- `etherscan.customChains` entries pointing at the Blockscout instances:
  - `https://api.scan.pulsechain.com/api` → `https://scan.pulsechain.com`
  - `https://api.scan.v4.testnet.pulsechain.com/api` → `https://scan.v4.testnet.pulsechain.com`

## Notes

- PulseChain runs **Blockscout**, not Etherscan. No API key is required; `hardhat-verify` accepts an empty string via the existing `apiKey` map pattern used for `lens`/`lensTestnet`.
- The two RPC URLs are the canonical public endpoints operated by the PulseChain team. Both are override-able via hardhat `vars` just like every other network in this config.
- The diff follows the exact shape of #276 (Lens) and #282 (Tempo) so it should slot in naturally.

## Context

Filed alongside deployment request #287. The existing pre-signed raw txs bundled in this repo all hardcode `gasPrice = 100 gwei`, which is ~12,000× below PulseChain's EIP-1559 base fee (~1.2M gwei at the time of filing) — so a cast-publish of any existing tx fails with `transaction underpriced`. Once you re-sign a fresh tx with a PulseChain-appropriate gas price (I'm happy to courtesy-fund `0xeD456e05CaAb11d66C4c797dD6c1D6f9A7F352b5` on PulseChain to speed this along), this PR makes the network/verify config ready to go.

No behavioural change for any existing network.