### PR TITLE
➕ Add Robinhood Chain Test Network Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2374,6 +2374,7 @@ To verify a deployed [`CreateX`](./src/CreateX.sol) contract on a block explorer
 - [Tempo Testnet (Moderato)](https://explore.testnet.tempo.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [Lens Sepolia Testnet](https://explorer.testnet.lens.xyz/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 - [PulseChain Testnet (Testnet-V4)](https://scan.v4.testnet.pulsechain.com/#/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
+- [Robinhood Chain Testnet](https://explorer.testnet.chain.robinhood.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed)
 
 ## Integration With External Tooling
 

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -1422,7 +1422,8 @@
     "name": "Robinhood Chain Testnet",
     "chainId": 46630,
     "urls": [
-      "https://explorer.testnet.chain.robinhood.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+      "https://explorer.testnet.chain.robinhood.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed",
+      "https://repo.sourcify.dev/46630/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
   }
 ]

--- a/deployments/deployments.json
+++ b/deployments/deployments.json
@@ -1417,5 +1417,12 @@
     "urls": [
       "https://scan.v4.testnet.pulsechain.com/#/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     ]
+  },
+  {
+    "name": "Robinhood Chain Testnet",
+    "chainId": 46630,
+    "urls": [
+      "https://explorer.testnet.chain.robinhood.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
+    ]
   }
 ]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1276,6 +1276,14 @@ const config: HardhatUserConfig = {
       url: vars.get("PULSECHAIN_MAINNET_URL", "https://rpc.pulsechain.com"),
       accounts,
     },
+    robinhoodChainTestnet: {
+      chainId: 46630,
+      url: vars.get(
+        "ROBINHOOD_CHAIN_TESTNET_URL",
+        "https://rpc.testnet.chain.robinhood.com",
+      ),
+      accounts,
+    },
   },
   contractSizer: {
     alphaSort: true,
@@ -1598,6 +1606,8 @@ const config: HardhatUserConfig = {
       // For PulseChain testnet & mainnet
       pulsechain: vars.get("PULSECHAIN_API_KEY", ""),
       pulsechainTestnet: vars.get("PULSECHAIN_API_KEY", ""),
+      // For Robinhood Chain testnet
+      robinhoodChainTestnet: vars.get("ROBINHOOD_CHAIN_API_KEY", ""),
     },
     customChains: [
       {
@@ -3037,6 +3047,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://api.scan.v4.testnet.pulsechain.com/api",
           browserURL: "https://scan.v4.testnet.pulsechain.com",
+        },
+      },
+      {
+        network: "robinhoodChainTestnet",
+        chainId: 46630,
+        urls: {
+          apiURL: "https://explorer.testnet.chain.robinhood.com/api",
+          browserURL: "https://explorer.testnet.chain.robinhood.com",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
     "deploy:lensmain": "npx hardhat run --no-compile --network lensMain scripts/deploy.ts",
     "deploy:pulsechaintestnet": "npx hardhat run --no-compile --network pulsechainTestnet scripts/deploy.ts",
     "deploy:pulsechainmain": "npx hardhat run --no-compile --network pulsechainMain scripts/deploy.ts",
+    "deploy:robinhoodchaintestnet": "npx hardhat run --no-compile --network robinhoodChainTestnet scripts/deploy.ts",
     "prettier:check": "prettier -c \"**/*.{js,ts,md,sol,json,yml,yaml}\"",
     "prettier:check:interface": "pnpm -C interface prettier:check",
     "prettier:fix": "prettier -w \"**/*.{js,ts,md,sol,json,yml,yaml}\"",


### PR DESCRIPTION
### 🕓 Changelog

Add Robinhood Chain test network deployment:
- [Robinhood Chain Testnet](https://explorer.testnet.chain.robinhood.com/address/0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed).

#### Verification

Compare the `keccak256` hash of the runtime bytecode with the canonical `keccak256` hash of the runtime bytecode [here](https://github.com/pcaversaccio/createx#security-considerations) (`0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f`):

```console
~$ cast keccak $(cast code 0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed --rpc-url https://rpc.testnet.chain.robinhood.com)
0xbd8a7ea8cfca7b4e5f5041d7d4b17bc317c5ce42cfbc42066a00cf26b43eb53f
```

#### 🐶 Cute Animal Picture

<img src=https://github.com/user-attachments/assets/c1869afa-9194-4b4f-bd0a-58c85205e960 width="1050"/>